### PR TITLE
Remove unused header.

### DIFF
--- a/src/string.c
+++ b/src/string.c
@@ -5,7 +5,6 @@ See the file LICENSE for details.
 */
 
 #include "string.h"
-#include "errno.h"
 #include "process.h"
 #include "console.h"
 #include "kerneltypes.h"


### PR DESCRIPTION
errno.h is an external dependency which causes compilation to fail:

gcc -Wall -c -ffreestanding -m32 -march=i386 string.c -o string.o
In file included from /usr/include/features.h:389:0,
                 from /usr/include/errno.h:28,
                 from string.c:8:
/usr/include/gnu/stubs.h:7:27: fatal error: gnu/stubs-32.h: No such file or directory
compilation terminated.
Makefile:19: recipe for target 'string.o' failed
make: *** [string.o] Error 1

This is caused by missing 32-bit header support on my system.

Fortunately stdarg.h (the only external header) is usable.