### PR TITLE
Fix ATAPI Probes

### DIFF
--- a/src/ata.c
+++ b/src/ata.c
@@ -25,7 +25,7 @@ See the file LICENSE for details.
 #define ATA_BASE2	0x1E8
 #define ATA_BASE3	0x168
 
-#define ATA_TIMEOUT     5
+#define ATA_TIMEOUT     3
 
 #define ATA_DATA	0   /* data register */
 #define ATA_ERROR	1   /* error register */
@@ -164,7 +164,16 @@ static int ata_begin( int id, int command, int nblocks, int offset )
 	outb(flags,base+ATA_FDH);
 
 	// wait again for the disk to indicate ready
-	if(!ata_wait(id,ATA_STATUS_BSY|ATA_STATUS_RDY,ATA_STATUS_RDY)) return 0;
+	// special case: ATAPI identification does not raise RDY flag
+
+	int ready;
+	if(command==ATAPI_COMMAND_IDENTIFY) {
+		ready = ata_wait(id,ATA_STATUS_BSY,0);
+	} else {
+		ready = ata_wait(id,ATA_STATUS_BSY|ATA_STATUS_RDY,ATA_STATUS_RDY);
+	}
+
+	if(!ready) return 0;
 
 	// send the arguments
 	outb(0,base+ATA_CONTROL);
@@ -333,17 +342,24 @@ int ata_probe( int id, int *nblocks, int *blocksize, char *name )
 	char *cbuffer = (char*)buffer;
 
 	/*
-	First attempt to modify a controller register.
-	If the change does not stick, there is not controller!
+	Check for 0xff in the controller status, which indicates
+	there is no device attached to the controller.
 	*/
 
-	t = inb(ata_base[id]+ATA_CYL_LO);
-	outb(~t,ata_base[id]+ATA_CYL_LO);
-	if(inb(ata_base[id]+ATA_CYL_LO)==t) return 0;
+	t = inb(ata_base[id]+ATA_STATUS);
+	if(t==0xff) return 0;
+
+	/* Reset the unit to be sure. */
+	ata_reset(id);
+
+	/*
+	It is now reasonably certain there is some kind of device attached.
+	Attempt to identify it, first as an ATA device, then ATAPI.
+	XXX Would be better to examine registers to determine which type
+	of identify to perform first.
+	*/
 
 	memset(cbuffer,0,512);
-
-	ata_reset(id);
 
 	if(ata_identify(id,ATA_COMMAND_IDENTIFY,cbuffer)) {
 		*nblocks = buffer[1]*buffer[3]*buffer[6];

--- a/src/ata.c
+++ b/src/ata.c
@@ -231,7 +231,7 @@ static int atapi_begin( int id, void *data, int length )
 	outb(flags,base+ATA_FDH);
 
 	// wait again for the disk to indicate ready
-	if(!ata_wait(id,ATA_STATUS_BSY|ATA_STATUS_RDY,ATA_STATUS_RDY)) return 0;
+	if(!ata_wait(id,ATA_STATUS_BSY,0)) return 0;
 
 	// send the arguments
 	outb(0,base+ATAPI_FEATURE);


### PR DESCRIPTION
Modify handling of ATAPI devices -- do not check for the RDY bit in status when performing IDENTIFY or SCSI_READ.  Also in configuration, test for presence of controller by comparing status bit to 0xff.

Closes #2 
