### PR TITLE
Fixed PIC Slave bug

### DIFF
--- a/src/pic.c
+++ b/src/pic.c
@@ -41,6 +41,7 @@ void pic_enable( uint8_t irq )
 		mask = mask&~(1<<irq);
 		outb(mask,pic_data[0]);
 	} else {
+		irq -= 8;
 		mask = inb(pic_data[1]);
 		mask = mask&~(1<<irq);
 		outb(mask,pic_data[1]);
@@ -56,6 +57,7 @@ void pic_disable( uint8_t irq )
 		mask = mask|(1<<irq);
 		outb(mask,pic_data[0]);
 	} else {
+		irq -= 8;
 		mask = inb(pic_data[1]);
 		mask = mask|(1<<irq);
 		outb(mask,pic_data[1]);


### PR DESCRIPTION
This fixes an issue with the creation of an interrupt mask
for the slave PIC. The IRQ value being used to generate the mask
was not relative to the slave, and so resulted in shifting values
too far, and generating clear masks (all 1's). This disabled all
interrupts for the slave PIC instead of enabling certain ones.
