### PR TITLE
ata.c: unset ata_interrupt_active flag on ata_interrupt complete

### DIFF
--- a/src/ata.c
+++ b/src/ata.c
@@ -241,7 +241,7 @@ static int atapi_begin( int id, void *data, int length )
 	outb(ATAPI_COMMAND_PACKET,base+ATA_COMMAND);
 
 	// wait for ready
-	if(!ata_wait(id,ATA_STATUS_BSY|ATA_STATUS_DRQ,ATA_STATUS_DRQ));
+	if(!ata_wait(id,ATA_STATUS_BSY|ATA_STATUS_DRQ,ATA_STATUS_DRQ)) return 0;
 
 	// send the ATAPI packet
 	ata_pio_write(id,data,length);


### PR DESCRIPTION
This is the change that I mentioned in our discussion where cdromfs halts indefinitely.

Let me know if that looks okay.