### PR TITLE
string: prevent integer overflow in printf_putint

### DIFF
--- a/src/string.c
+++ b/src/string.c
@@ -157,11 +157,9 @@ static void printf_putint( int32_t i )
 	}
 
 	f = 1;
-	while((i/f)>0) {
+	while((i/f) >= 10) {
 		f*=10;
 	}
-	f=f/10;
-	if(f==0) f=1;
 	while(f>0) {
 		d = i/f;
 		printf_putchar('0'+d);


### PR DESCRIPTION
Instead of letting f (the place value iterator) get larger than i (the
subject to be printed) and protentially overflow, stop the loop when f
is at exactly the largest place value the number has, rather than one
place value greater.