### PR TITLE
Added new fall-through low color video mode so VMware can boot

### DIFF
--- a/src/kernelcore.S
+++ b/src/kernelcore.S
@@ -123,6 +123,12 @@ video640:
 	int	$0x10
 	cmp	$0x004f, %ax
 	je	videodone
+video640_lowcolor:
+	mov	$0x4f02, %ax
+	mov	$0x4111, %bx
+	int	$0x10
+	cmp	$0x004f, %ax
+	je	videodone
 
 videofailed:
 	mov	$videomsg, %esi


### PR DESCRIPTION
For VBE 2.0 and onward, it is not mandatory to support the numbered VBE modes. VMware Player 12 does not seem to support the currently implemented video modes, so as a temporary work around I found one that it does support and added it after the current default 640x480 video mode. Going forward it might be wise to try enumerating the supported video modes and choosing one of them rather than just trying different numbered modes.