### PR TITLE
Execute Simple User Program From CDROM

### DIFF
--- a/src/Makefile
+++ b/src/Makefile
@@ -8,7 +8,7 @@ ISOGEN?=genisoimage
 all: basekernel.iso test.exe
 
 basekernel.iso: basekernel.img
-	${ISOGEN} -J -R -o basekernel.iso -b basekernel.img basekernel.img
+	${ISOGEN} -J -R -o basekernel.iso -b basekernel.img basekernel.img test.exe
 
 basekernel.img: bootblock kernel
 	cat bootblock kernel /dev/zero | head -c 1474560 > basekernel.img

--- a/src/cdromfs.h
+++ b/src/cdromfs.h
@@ -9,13 +9,19 @@ See the file LICENSE for details.
 
 #include "kerneltypes.h"
 
+#define CDROM_BLOCK_SIZE 2048
+
 struct cdrom_volume * cdrom_volume_open( int unit );
 void                  cdrom_volume_close( struct cdrom_volume *v );
 struct cdrom_dirent * cdrom_volume_root( struct cdrom_volume *v );
+int                   cdrom_volume_block_size( struct cdrom_volume *v );
 
-int  cdrom_dirent_read( struct cdrom_dirent *d, char *data, int length );
-int  cdrom_dirent_readdir( struct cdrom_dirent *d, char *buffer, int buffer_length );
+struct cdrom_dirent * cdrom_dirent_namei( struct cdrom_dirent *d, const char *path );
+struct cdrom_dirent * cdrom_dirent_lookup( struct cdrom_dirent *d, const char *name );
 
+int  cdrom_dirent_length( struct cdrom_dirent *d );
+int  cdrom_dirent_read_block( struct cdrom_dirent *d, char *buffer, int nblock );
+int  cdrom_dirent_read_dir( struct cdrom_dirent *d, char *buffer, int buffer_length );
 void cdrom_dirent_close( struct cdrom_dirent *d );
 
 #endif

--- a/src/interrupt.c
+++ b/src/interrupt.c
@@ -41,14 +41,12 @@ static void unknown_exception( int i, int code )
 	if(i==14) {
 		asm("mov %%cr2, %0" : "=r" (vaddr) );
 		if(pagetable_getmap(current->pagetable,vaddr,&paddr)) {
-			console_printf("\finterrupt: illegal page access at vaddr %x\n",vaddr);
+			console_printf("interrupt: illegal page access at vaddr %x\n",vaddr);
 			process_dump(current);
 			process_exit(0);
 		} else {
-			printf("interrupt: page fault at %x\n",vaddr);
-			printf("please write a fault handler in interrupt.c!\n");
-			printf("kernel halted.\n");
-			halt();
+			pagetable_alloc(current->pagetable,vaddr,PAGE_SIZE,PAGE_FLAG_USER|PAGE_FLAG_READWRITE);
+			return;
 		}
 	} else {
 		console_printf("\finterrupt: exception %d: %s (code %x)\n",i,exception_names[i],code);

--- a/src/main.c
+++ b/src/main.c
@@ -50,18 +50,48 @@ int kernel_main()
 	ata_init();
 
 	/*
-	Test out some basic operations by opening a filesystem
-	and displaying the root directory.
+	Test out some basic operations by listing the root filesystem,
+	then creating a child process.
 	*/
 
+	printf("\nLIST ROOT DIRECTORY:\n");
+	list_directory("/");
+
+	printf("\nRUN CHILD PROCESS:\n");
+	sys_run("/TEST.EXE");
+	process_yield();
+
+	console_printf("\nBASEKERNEL READY:\n");
+
+	while(1) console_putchar(keyboard_read());
+
+	return 0;
+}
+
+int print_directory( char *d, int length )
+{
+	while(length>0) {
+		console_printf("%s\n",d);
+		int len = strlen(d)+1;
+		d += len;
+		length -= len;
+	}
+	return 0;
+}
+
+int list_directory( const char *path )
+{
 	struct cdrom_volume *v = cdrom_volume_open(1);
 	if(v) {
 		struct cdrom_dirent *d = cdrom_volume_root(v);
 		if(d) {
 			int buffer_length = 1024;
 			char *buffer = kmalloc(buffer_length);
-			int length = cdrom_dirent_readdir(d,buffer,buffer_length);
-			print_directory(buffer,length);
+			if(buffer) {
+				int length = cdrom_dirent_readdir(d,buffer,buffer_length);
+				print_directory(buffer,length);
+				kfree(buffer);
+			}
 			cdrom_dirent_close(d);
 		} else {
 			printf("couldn't access root dir!\n");
@@ -71,20 +101,5 @@ int kernel_main()
 		printf("couldn't mount filesystem!\n");
 	}
 
-	console_printf("\nBASEKERNEL READY:\n");
-
-	while(1) console_putchar(keyboard_read());
-
 	return 0;
-}
-
-
-void print_directory( char *d, int length )
-{
-	while(length>0) {
-		console_printf("%s\n",d);
-		int len = strlen(d)+1;
-		d += len;
-		length -= len;
-	}
 }

--- a/src/process.c
+++ b/src/process.c
@@ -71,6 +71,11 @@ struct process * process_create( unsigned code_size, unsigned stack_size )
 	return p;
 }
 
+void process_launch( struct process *p )
+{
+	list_push_tail(&ready_list,&p->node);
+}
+
 static void process_switch( int newstate )
 {
 	interrupt_block();

--- a/src/process.h
+++ b/src/process.h
@@ -32,6 +32,8 @@ struct process {
 void process_init();
 
 struct process * process_create( unsigned code_size, unsigned stack_size );
+void process_launch( struct process *p );
+
 void process_yield();
 void process_preempt();
 void process_exit( int code );

--- a/src/syscall.h
+++ b/src/syscall.h
@@ -12,8 +12,7 @@ See the file LICENSE for details.
 typedef enum {
 	SYSCALL_DEBUG,
 	SYSCALL_YIELD,
-	SYSCALL_FORK,
-	SYSCALL_EXEC,
+	SYSCALL_RUN,
 	SYSCALL_WAIT,
 	SYSCALL_EXIT,
 	SYSCALL_OPEN,
@@ -24,10 +23,10 @@ typedef enum {
 } syscall_t;
 
 typedef enum {
-	ENOENT,
-	EINVAL,
-	EACCES,
-	ENOSYS
+	ENOENT=-1,
+	EINVAL=-2,
+	EACCES=-3,
+	ENOSYS=-4
 } syscall_error_t;
 
 uint32_t syscall( syscall_t s, uint32_t a, uint32_t b, uint32_t c, uint32_t d, uint32_t e );
@@ -41,11 +40,8 @@ static inline void exit( int status )
 static inline int yield()
 	{ return syscall( SYSCALL_YIELD, 0, 0, 0, 0, 0 ); }
 
-static inline int fork()
-	{ return syscall( SYSCALL_FORK, 0, 0, 0, 0, 0 ); }
-
-static inline int exec( const char *cmd )
-	{ return syscall( SYSCALL_EXEC, (uint32_t) cmd, 0, 0, 0, 0 ); }
+static inline int run( const char *cmd )
+	{ return syscall( SYSCALL_RUN, (uint32_t) cmd, 0, 0, 0, 0 ); }
 
 static inline int wait()
 	{ return syscall( SYSCALL_WAIT, 0, 0, 0, 0, 0 ); }
@@ -63,6 +59,6 @@ static inline int lseek( int fd, int offset, int whence )
 	{ return syscall( SYSCALL_LSEEK, fd, offset, whence, 0, 0 ); }
 
 static inline int close( int fd )
-{ return syscall( SYSCALL_CLOSE, fd, 0, 0, 0, 0 ); }
+	{ return syscall( SYSCALL_CLOSE, fd, 0, 0, 0, 0 ); }
 
 #endif

--- a/src/test.c
+++ b/src/test.c
@@ -23,7 +23,7 @@ int main( const char *argv[], int argc )
 	int i, j;
 
 	for(j=0;j<10;j++) {
-		write(1,"hello world!\n",13);
+		debug("hello world!\n");
      		for(i=0;i<100000000;i++)  {}
 	}
 


### PR DESCRIPTION
Implements system call `sys_run` which creates a child process and loads an executable into it.
`main` expects the CDROM to be mounted as unit 1 and loads the program `TEST.EXE` from it.
This simple program exercises the `debug` and `exit` system calls.
Ideally, `sys_run` would not invoke the cdrom directly but instead go through an abstract filesystem interface.

