### PR TITLE
Added getpid syscall

### DIFF
--- a/src/process.c
+++ b/src/process.c
@@ -16,6 +16,7 @@ See the file LICENSE for details.
 
 struct process *current=0;
 struct list ready_list = {0,0};
+uint32_t current_pid = 1;
 
 void process_init()
 {
@@ -65,6 +66,7 @@ struct process * process_create( unsigned code_size, unsigned stack_size )
 
 	p->kstack = memory_alloc_page(1);
 	p->entry = PROCESS_ENTRY_POINT;
+	p->pid = current_pid++;
 
 	process_stack_init(p);
 
@@ -184,5 +186,9 @@ void process_dump( struct process *p)
 	console_printf("ebp: %x\n",s->regs1.ebp);
 	console_printf("esp: %x\n",s->esp);
 	console_printf("eip: %x\n",s->eip);
+}
+
+uint32_t process_getpid() {
+    return current->pid;
 }
 

--- a/src/process.c
+++ b/src/process.c
@@ -192,3 +192,6 @@ uint32_t process_getpid() {
     return current->pid;
 }
 
+uint32_t process_getppid() {
+    return current->ppid;
+}

--- a/src/process.h
+++ b/src/process.h
@@ -27,6 +27,7 @@ struct process {
 	char *kstack_top;
 	char *stack_ptr;
 	uint32_t entry;
+	uint32_t pid;
 };
 
 void process_init();
@@ -42,6 +43,8 @@ void process_dump( struct process *p );
 void process_wait( struct list *q );
 void process_wakeup( struct list *q );
 void process_wakeup_all( struct list *q );
+
+uint32_t process_getpid();
 
 extern struct process *current;
 

--- a/src/process.h
+++ b/src/process.h
@@ -28,6 +28,7 @@ struct process {
 	char *stack_ptr;
 	uint32_t entry;
 	uint32_t pid;
+	uint32_t ppid;
 };
 
 void process_init();
@@ -45,6 +46,7 @@ void process_wakeup( struct list *q );
 void process_wakeup_all( struct list *q );
 
 uint32_t process_getpid();
+uint32_t process_getppid();
 
 extern struct process *current;
 

--- a/src/syscall.h
+++ b/src/syscall.h
@@ -19,7 +19,8 @@ typedef enum {
 	SYSCALL_READ,
 	SYSCALL_WRITE,
 	SYSCALL_LSEEK,
-	SYSCALL_CLOSE
+	SYSCALL_CLOSE,
+	SYSCALL_GETPID
 } syscall_t;
 
 typedef enum {

--- a/src/syscall.h
+++ b/src/syscall.h
@@ -20,7 +20,8 @@ typedef enum {
 	SYSCALL_WRITE,
 	SYSCALL_LSEEK,
 	SYSCALL_CLOSE,
-	SYSCALL_GETPID
+	SYSCALL_GETPID,
+	SYSCALL_GETPPID
 } syscall_t;
 
 typedef enum {

--- a/src/syscall_handler.c
+++ b/src/syscall_handler.c
@@ -76,6 +76,9 @@ int sys_run( const char *path )
 	cdrom_dirent_close(d);
 	cdrom_volume_close(v);
 
+    /* Set the parent of the new process to the calling process */
+    p->ppid = process_getpid();
+
 	/* Put the new process into the ready list */
 
 	process_launch(p);
@@ -118,6 +121,11 @@ int sys_getpid()
 	return process_getpid();
 }
 
+int sys_getppid()
+{
+	return process_getppid();
+}
+
 int32_t syscall_handler( syscall_t n, uint32_t a, uint32_t b, uint32_t c, uint32_t d, uint32_t e )
 {
 	switch(n) {
@@ -132,6 +140,7 @@ int32_t syscall_handler( syscall_t n, uint32_t a, uint32_t b, uint32_t c, uint32
 	case SYSCALL_LSEEK:	return sys_lseek(a,b,c);
 	case SYSCALL_CLOSE:	return sys_close(a);
 	case SYSCALL_GETPID:	return sys_getpid();
+	case SYSCALL_GETPPID:	return sys_getppid();
 	default:		return -1;
 	}
 }

--- a/src/syscall_handler.c
+++ b/src/syscall_handler.c
@@ -113,6 +113,11 @@ int sys_close( int fd )
 	return ENOSYS;
 }
 
+int sys_getpid()
+{
+	return process_getpid();
+}
+
 int32_t syscall_handler( syscall_t n, uint32_t a, uint32_t b, uint32_t c, uint32_t d, uint32_t e )
 {
 	switch(n) {
@@ -126,6 +131,7 @@ int32_t syscall_handler( syscall_t n, uint32_t a, uint32_t b, uint32_t c, uint32
 	case SYSCALL_WRITE:	return sys_write(a,(void*)b,c);
 	case SYSCALL_LSEEK:	return sys_lseek(a,b,c);
 	case SYSCALL_CLOSE:	return sys_close(a);
+	case SYSCALL_GETPID:	return sys_getpid();
 	default:		return -1;
 	}
 }

--- a/src/syscalls.c
+++ b/src/syscalls.c
@@ -47,5 +47,11 @@ int close( int fd ) {
 }
 
 int getpid() {
-	return syscall( SYSCALL_GETPID, 0, 0, 0, 0, 0 );
+    static int cache = 0;
+    return cache? (cache) : (cache=syscall( SYSCALL_GETPID, 0, 0, 0, 0, 0 ));
+}
+
+int getppid() {
+    static int cache = 0;
+    return cache? (cache) : (cache=syscall( SYSCALL_GETPPID, 0, 0, 0, 0, 0 ));
 }

--- a/src/syscalls.c
+++ b/src/syscalls.c
@@ -45,3 +45,7 @@ int lseek( int fd, int offset, int whence ) {
 int close( int fd ) {
 	return syscall( SYSCALL_CLOSE, fd, 0, 0, 0, 0 );
 }
+
+int getpid() {
+	return syscall( SYSCALL_GETPID, 0, 0, 0, 0, 0 );
+}

--- a/src/syscalls.h
+++ b/src/syscalls.h
@@ -17,5 +17,6 @@ int read( int fd, void *data, int length );
 int write( int fd, void *data, int length );
 int lseek( int fd, int offset, int whence );
 int close( int fd );
+int getpid();
 
 #endif

--- a/src/syscalls.h
+++ b/src/syscalls.h
@@ -18,5 +18,6 @@ int write( int fd, void *data, int length );
 int lseek( int fd, int offset, int whence );
 int close( int fd );
 int getpid();
+int getppid();
 
 #endif


### PR DESCRIPTION
I added the getpid system call.
The only reason this is marked WIP is because in linux the function `getpid` is cached, and was wondering if we'd want ours cached too.
Would something like
```
int getpid() {
	static int cache = 0;
	return cache? (cache) : (cache=syscall( SYSCALL_GETPID, 0, 0, 0, 0, 0 ));
}
```
work here, and should something like that be implemented?