### PR TITLE
Fix process_run and keyboard_read_char

### DIFF
--- a/src/syscalls.c
+++ b/src/syscalls.c
@@ -39,7 +39,7 @@ int close( int fd ) {
 	return syscall( SYSCALL_CLOSE, fd, 0, 0, 0, 0 );
 }
 
-int keyboard_read_char() {
+char keyboard_read_char() {
 	return syscall( SYSCALL_KEYBOARD_READ_CHAR, 0, 0, 0, 0, 0 );
 }
 

--- a/src/syscalls.h
+++ b/src/syscalls.h
@@ -13,7 +13,7 @@ See the file LICENSE for details.
 void debug( const char *str );
 void exit( int status );
 int yield();
-int run( const char *cmd, const char** argv, int argc );
+int process_run( const char *cmd, const char** argv, int argc );
 int open( const char *path, int mode, int flags );
 int read( int fd, void *data, int length );
 int write( int fd, void *data, int length );


### PR DESCRIPTION
`process_run` was declared as `run`, which is fixed.
The return type of `keyboard_read_char` was also incorrect, which is fixed.