### PR TITLE
Serial logging demo

### DIFF
--- a/src/Makefile
+++ b/src/Makefile
@@ -1,4 +1,4 @@
-KERNEL_OBJECTS=kernelcore.o main.o console.o memory.o keyboard.o mouse.o clock.o interrupt.o kmalloc.o pic.o ata.o cdromfs.o string.o bitmap.o graphics.o font.o syscall_handler.o process.o mutex.o list.o pagetable.o rtc.o kshell.o fs.o kevinfs/kevinfs.o hashtable.o kevinfs/kevinfs_test.o kevinfs/kevinfs_ata.o
+KERNEL_OBJECTS=kernelcore.o main.o console.o memory.o keyboard.o mouse.o clock.o interrupt.o kmalloc.o pic.o ata.o cdromfs.o string.o bitmap.o graphics.o font.o syscall_handler.o process.o mutex.o list.o pagetable.o rtc.o kshell.o fs.o kevinfs/kevinfs.o hashtable.o kevinfs/kevinfs_test.o kevinfs/kevinfs_ata.o com.o
 
 USER_OBJECTS=user-start.o test.o syscall.o syscalls.o string.o user-io.o
 

--- a/src/com.c
+++ b/src/com.c
@@ -1,0 +1,41 @@
+#include "kerneltypes.h"
+#include "ioports.h"
+
+#define PORT 0x3f8   /* COM1 */
+ 
+void init_serial() {
+   outb(0x03, PORT + 1);    // Disable all interrupts
+   outb(0x80, PORT + 3);    // Enable DLAB (set baud rate divisor)
+   outb(0x03, PORT + 0);    // Set divisor to 3 (lo byte) 38400 baud
+   outb(0x00, PORT + 1);    //                  (hi byte)
+   outb(0x03, PORT + 3);    // 8 bits, no parity, one stop bit
+   outb(0xC7, PORT + 2);    // Enable FIFO, clear them, with 14-byte threshold
+   outb(0x0B, PORT + 4);    // IRQs enabled, RTS/DSR set
+}
+
+static int serial_received() {
+   return inb(PORT + 5) & 1;
+}
+
+static int is_transmit_empty() {
+   return inb(PORT + 5) & 0x20;
+}
+ 
+char read_serial() {
+   while (serial_received() == 0);
+ 
+   return inb(PORT);
+}
+
+void write_serial(char a) {
+   while (is_transmit_empty() == 0);
+ 
+   outb(a, PORT);
+}
+
+void write_string_serial(char *s)
+{
+   while (*s) {
+	   write_serial(*s++);
+   }
+}

--- a/src/com.h
+++ b/src/com.h
@@ -1,0 +1,7 @@
+#ifndef COM_H
+#define COM_H
+void init_serial();
+char read_serial();
+void write_serial(char a);
+void write_string_serial(char *s);
+#endif

--- a/src/console.c
+++ b/src/console.c
@@ -5,6 +5,7 @@ See the file LICENSE for details.
 */
 
 #include "console.h"
+#include "com.h"
 #include "graphics.h"
 
 static int xsize=80;
@@ -46,6 +47,9 @@ void console_heartbeat()
 
 void console_putchar( char c )
 {
+#ifdef TEST
+	write_serial(c);
+#endif
 	console_writechar(xpos,ypos,' ');
 
 	switch(c) {

--- a/src/main.c
+++ b/src/main.c
@@ -25,6 +25,7 @@ See the file LICENSE for details.
 #include "cdromfs.h"
 #include "kevinfs/kevinfs_test.h"
 #include "kevinfs/kevinfs.h"
+#include "com.h"
 
 struct dirent *root_directory = 0;
 struct dirent *current_directory = 0;
@@ -41,6 +42,9 @@ int kernel_main()
 	struct graphics *g = graphics_create_root();
 
 	console_init(g);
+#ifdef TEST
+	init_serial();
+#endif
 
 	console_printf("video: %d x %d\n",video_xres,video_yres,video_xbytes);
 	console_printf("kernel: %d bytes\n",kernel_size);


### PR DESCRIPTION
How to run:

    make CFLAGS='-Wall -c -ffreestanding -fno-pie -DTEST'
    qemu-system-i386 -cdrom basekernel.iso -hda disk.img -serial file:basekernel.log

Check the output:

    cat basekernel.log

This will log everything outside of user input (because logging certain characters from streams makes the log way less readable, i.e. ' ', '_')