### PR TITLE
Correct kshell 

### DIFF
--- a/src/kshell.c
+++ b/src/kshell.c
@@ -87,7 +87,7 @@ static int process_command(char *line)
 			process_yield();
 		}
 		else
-			list_directory("run: missing argument");
+			printf("start: missing argument\n");
 	}
 	else if (pch && !strcmp(pch, "run"))
 	{
@@ -106,7 +106,7 @@ static int process_command(char *line)
             }
 		}
 		else
-			list_directory("run: missing argument");
+			printf("run: missing argument\n");
 	}
 	else if (pch && !strcmp(pch, "mount"))
 	{


### PR DESCRIPTION
Run and start, if ran without arguments, called list_dir.  This is a typo, it should be printf.