### PR TITLE
Add lowercase cdromfs files, in appearance

### DIFF
--- a/src/cdromfs.c
+++ b/src/cdromfs.c
@@ -31,6 +31,7 @@ struct cdrom_dirent {
 
 static struct fs_volume *cdrom_volume_as_volume(struct cdrom_volume *cdv);
 static struct fs_dirent *cdrom_dirent_as_dirent(struct cdrom_dirent *cdd);
+char * strdup(const char * s);
 void strtoupper(char * name);
 void strtolower(char * name);
 
@@ -119,9 +120,8 @@ static struct fs_dirent * cdrom_dirent_lookup( struct fs_dirent *dir, const char
 	int data_length = cddir->length;
 
 	struct iso_9660_directory_entry *d = (struct iso_9660_directory_entry *) data;
-	char *upper_name = kmalloc(strlen(name));
+	char *upper_name = strdup(name);
   if (!upper_name) return 0;
-  strcpy(upper_name, name);
   strtoupper(upper_name);
 
 	while(data_length>0 && d->descriptor_length>0 ) {
@@ -188,6 +188,13 @@ static int cdrom_dirent_read_dir( struct fs_dirent *dir, char *buffer, int buffe
 	kfree(data);
 
 	return total;
+}
+
+char * strdup(const char * s) {
+  char * new = kmalloc(strlen(s));
+  if (new)
+    strcpy(new, s);
+  return new;
 }
 
 void strtoupper(char * name) {

--- a/src/cdromfs.c
+++ b/src/cdromfs.c
@@ -191,7 +191,7 @@ static int cdrom_dirent_read_dir( struct fs_dirent *dir, char *buffer, int buffe
 }
 
 char * strdup(const char * s) {
-  char * new = kmalloc(strlen(s));
+  char * new = kmalloc(strlen(s) + 1);
   if (new)
     strcpy(new, s);
   return new;

--- a/src/cdromfs.c
+++ b/src/cdromfs.c
@@ -31,8 +31,8 @@ struct cdrom_dirent {
 
 static struct fs_volume *cdrom_volume_as_volume(struct cdrom_volume *cdv);
 static struct fs_dirent *cdrom_dirent_as_dirent(struct cdrom_dirent *cdd);
-void make_lower(char * name);
-void make_upper(char * name);
+void strtoupper(char * name);
+void strtolower(char * name);
 
 static struct cdrom_dirent * cdrom_dirent_create( struct cdrom_volume *volume, int sector, int length, int isdir )
 {
@@ -122,7 +122,7 @@ static struct fs_dirent * cdrom_dirent_lookup( struct fs_dirent *dir, const char
 	char *upper_name = kmalloc(strlen(name));
   if (!upper_name) return 0;
   strcpy(upper_name, name);
-  make_upper(upper_name);
+  strtoupper(upper_name);
 
 	while(data_length>0 && d->descriptor_length>0 ) {
 		fix_filename(d->ident,d->ident_length);
@@ -176,7 +176,7 @@ static int cdrom_dirent_read_dir( struct fs_dirent *dir, char *buffer, int buffe
 		} else {
 			strcpy(buffer,d->ident);
 			int len = strlen(d->ident) + 1;
-      make_lower(buffer);
+      strtolower(buffer);
 			buffer += len;
 			buffer_length -= len;
 			total += len;
@@ -190,7 +190,7 @@ static int cdrom_dirent_read_dir( struct fs_dirent *dir, char *buffer, int buffe
 	return total;
 }
 
-void make_upper(char * name) {
+void strtoupper(char * name) {
   while (*name) {
     if (*name >= 'a' && *name <= 'z') {
       *name -= 'a' - 'A';
@@ -199,7 +199,7 @@ void make_upper(char * name) {
   }
 }
 
-void make_lower(char * name) {
+void strtolower(char * name) {
   while (*name) {
     if (*name >= 'A' && *name <= 'Z') {
       *name += 'a' - 'A';

--- a/src/cdromfs.c
+++ b/src/cdromfs.c
@@ -31,6 +31,8 @@ struct cdrom_dirent {
 
 static struct fs_volume *cdrom_volume_as_volume(struct cdrom_volume *cdv);
 static struct fs_dirent *cdrom_dirent_as_dirent(struct cdrom_dirent *cdd);
+void make_lower(char * name);
+void make_upper(char * name);
 
 static struct cdrom_dirent * cdrom_dirent_create( struct cdrom_volume *volume, int sector, int length, int isdir )
 {
@@ -117,11 +119,15 @@ static struct fs_dirent * cdrom_dirent_lookup( struct fs_dirent *dir, const char
 	int data_length = cddir->length;
 
 	struct iso_9660_directory_entry *d = (struct iso_9660_directory_entry *) data;
+	char *upper_name = kmalloc(strlen(name));
+  if (!upper_name) return 0;
+  strcpy(upper_name, name);
+  make_upper(upper_name);
 
 	while(data_length>0 && d->descriptor_length>0 ) {
 		fix_filename(d->ident,d->ident_length);
 
-		if(!strcmp(name,d->ident)) {
+		if(!strcmp(upper_name,d->ident)) {
 			struct cdrom_dirent *r = cdrom_dirent_create(
 				cddir->volume,
 				d->first_sector_little,
@@ -129,6 +135,7 @@ static struct fs_dirent * cdrom_dirent_lookup( struct fs_dirent *dir, const char
 				d->flags & ISO_9660_EXTENT_FLAG_DIRECTORY );
 
 			kfree(data);
+      kfree(upper_name);
 			return cdrom_dirent_as_dirent(r);
 		}
 
@@ -137,6 +144,7 @@ static struct fs_dirent * cdrom_dirent_lookup( struct fs_dirent *dir, const char
 	}
 
 	kfree(data);
+	kfree(upper_name);
 
 	return 0;
 }
@@ -168,6 +176,7 @@ static int cdrom_dirent_read_dir( struct fs_dirent *dir, char *buffer, int buffe
 		} else {
 			strcpy(buffer,d->ident);
 			int len = strlen(d->ident) + 1;
+      make_lower(buffer);
 			buffer += len;
 			buffer_length -= len;
 			total += len;
@@ -179,6 +188,24 @@ static int cdrom_dirent_read_dir( struct fs_dirent *dir, char *buffer, int buffe
 	kfree(data);
 
 	return total;
+}
+
+void make_upper(char * name) {
+  while (*name) {
+    if (*name >= 'a' && *name <= 'z') {
+      *name -= 'a' - 'A';
+    }
+    name++;
+  }
+}
+
+void make_lower(char * name) {
+  while (*name) {
+    if (*name >= 'A' && *name <= 'Z') {
+      *name += 'a' - 'A';
+    }
+    name++;
+  }
 }
 
 static int cdrom_dirent_close( struct fs_dirent *d )


### PR DESCRIPTION
Addresses #93.

`cdromfs.c`'s read dir and dirent lookup now make files appear lowercase when using the cdromfs filesystem.

Documentation will be added at merge so that the documentation isn't out of sync with master.