### PR TITLE
Fix pagetable_delete typo

### DIFF
--- a/src/pagetable.c
+++ b/src/pagetable.c
@@ -150,7 +150,7 @@ void pagetable_delete( struct pagetable *p )
 		if(e->present) {
 			q = (struct pagetable *) (e->addr<<12);
 			for(j=0;j<ENTRIES_PER_TABLE;j++) {
-				e = &q->entry[i];
+				e = &q->entry[j];
 				if(e->present && e->avail) {
 					void *paddr;
 					paddr = (void *) (e->addr<<12);


### PR DESCRIPTION
I think this typo prevents many pages from being correctly freed.