### PR TITLE
Added wait forever option

### DIFF
--- a/src/kshell.c
+++ b/src/kshell.c
@@ -99,7 +99,7 @@ static int process_command(char *line)
 			int pid = sys_process_run(pch, argv, 2);
             printf("started process %d\n", pid);
             struct process_info info;
-            if (!process_wait_child(&info, 5000)) {
+            if (!process_wait_child(&info, -1)) {
                 printf("process %d exited with status %d\n", info.pid, info.exitcode);
                 process_reap(info.pid);
 

--- a/src/process.c
+++ b/src/process.c
@@ -434,7 +434,7 @@ int process_wait_child(struct process_info *info, int timeout) {
 		process_wait(&ready_list);
 		elapsed = clock_diff(start,clock_read());
 		total = elapsed.millis + elapsed.seconds*1000;
-	} while(total<timeout);
+	} while(total<timeout || timeout < 0);
     return 1;
 }
 


### PR DESCRIPTION
A process can now perform a wait on its children without a timeout (i.e. forever), by using a negative value for the timeout parameter.