### PR TITLE
Usability improvments for kshell and usrshell

### DIFF
--- a/src/kshell.c
+++ b/src/kshell.c
@@ -97,11 +97,15 @@ static int process_command(char *line)
 		if (pch) {
       const char* argv[] = {pch, "run"};
       int pid = sys_process_run(pch, argv, 2);
-      printf("started process %d\n", pid);
-      struct process_info info;
-      process_wait_child(&info, -1);
-      printf("process %d exited with status %d\n", info.pid, info.exitcode);
-      process_reap(info.pid);
+      if (pid >= 0) {
+        printf("started process %d\n", pid);
+        struct process_info info;
+        process_wait_child(&info, -1);
+        printf("process %d exited with status %d\n", info.pid, info.exitcode);
+        process_reap(info.pid);
+      } else {
+        printf("Error starting %s\n", pch);
+      }
 		}
 		else
 			printf("run: missing argument\n");


### PR DESCRIPTION
A collection of small improvements for the usability of kshell and usrshell

- usrshell's prompt is now `u$ `, so it's harder to get confused if you're using usrshell or kshell.
- usrshell now tracks if a namespace has been chosen, so operations requiring one don't error.
- More error checking in usrshell.
- kshell now checks if the running the program worked, so it doesn't hang waiting for a nonexistent program.
- usrshell's run and start now actually pass arguments.