### PR TITLE
Handle '.' accurately

### DIFF
--- a/src/fs_space.c
+++ b/src/fs_space.c
@@ -16,6 +16,7 @@ int fs_space_depth_check(const char *path, int cdepth) {
       break;
     } else if (!strcmp(part, "..")) {
       cdepth--;
+    } else if (strcmp(part, ".")) {
     } else {
       cdepth++;
     }


### PR DESCRIPTION
Currently a process can escape its ns_root by doing chdir'ing into something like `./././././../..`, since each "." is counted as going lower in the filesystem tree.