### PR TITLE
Fixed bugs in build process using cross-compiler

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -7,3 +7,4 @@
 *~
 kernel/kernel
 kernel/bootblock
+cross

--- a/Makefile.config
+++ b/Makefile.config
@@ -6,6 +6,7 @@ ISOGEN=genisoimage
 #
 CC=gcc -m32
 LD=ld -melf_i386
+AR=ar
 OBJCOPY=objcopy
 
 # If you are compiling from another platform,
@@ -13,4 +14,5 @@ OBJCOPY=objcopy
 # add cross/bin to your path, and uncomment these lines:
 #CC=i686-elf-gcc
 #LD=i686-elf-ld
+#AR=i686-elf-ar
 #OBJCOPY=i686-elf-objcopy

--- a/build-cross-compiler.sh
+++ b/build-cross-compiler.sh
@@ -1,5 +1,8 @@
 #!/bin/sh
 
+GCC="gcc-8.2.0"
+BINUTILS="binutils-2.31.1"
+
 PREFIX=`pwd`/cross
 WORKDIR=`mktemp -d`
 
@@ -10,31 +13,35 @@ pushd "$WORKDIR"
 
 # get and extract sources
 
-if [ ! -d binutils-2.29.1 ]
+if [ ! -d $BINUTILS ]
 then
-	curl -O https://ftp.gnu.org/gnu/binutils/binutils-2.29.1.tar.gz
-	tar -zxf binutils-2.29.1.tar.gz
+	curl -O https://ftp.gnu.org/gnu/binutils/$BINUTILS.tar.gz
+	tar -zxf $BINUTILS.tar.gz
 fi
 
-if [ ! -d gcc-7.2.0 ]
+if [ ! -d $GCC ]
 then
-	curl -O https://ftp.gnu.org/gnu/gcc/gcc-7.2.0/gcc-7.2.0.tar.gz
-	tar -zxf gcc-7.2.0.tar.gz
+	curl -O https://ftp.gnu.org/gnu/gcc/$GCC/$GCC.tar.gz
+	tar -zxf $GCC.tar.gz
 fi
 
 # build and install libtools
-cd binutils-2.29.1
+cd $BINUTILS
 ./configure --prefix="$PREFIX" --target=i686-elf --disable-nls --disable-werror --with-sysroot
 make && make install
 cd ..
 
+# download gcc prerequisites
+cd $GCC
+./contrib/download_prerequisites
+cd ..
+
 # build and install gcc
-mkdir gcc-7.2.0-elf-objs
-cd gcc-7.2.0-elf-objs
-../gcc-7.2.0/configure --prefix="$PREFIX" --target=i686-elf --disable-nls --enable-languages=c --without-headers
+mkdir $GCC-elf-objs
+cd $GCC-elf-objs
+../$GCC/configure --prefix="$PREFIX" --target=i686-elf --disable-nls --enable-languages=c --without-headers
 make all-gcc && make all-target-libgcc && make install-gcc && make install-target-libgcc
 cd ..
 
 popd
 rm -rf "$WORKDIR"
-

--- a/build-cross-compiler.sh
+++ b/build-cross-compiler.sh
@@ -3,13 +3,14 @@
 GCC="gcc-8.2.0"
 BINUTILS="binutils-2.31.1"
 
-PREFIX=`pwd`/cross
+CURRDIR=`pwd`
+PREFIX=$CURRDIR/cross
 WORKDIR=`mktemp -d`
 
 echo "Installing cross-compiler to $PREFIX"
 echo "Building in directory $WORKDIR"
 
-pushd "$WORKDIR"
+cd "$WORKDIR"
 
 # get and extract sources
 
@@ -43,5 +44,5 @@ cd $GCC-elf-objs
 make all-gcc && make all-target-libgcc && make install-gcc && make install-target-libgcc
 cd ..
 
-popd
+cd "$CURRDIR"
 rm -rf "$WORKDIR"

--- a/library/Makefile
+++ b/library/Makefile
@@ -8,7 +8,7 @@ all: user-start.o baselib.a
 	${CC} ${KERNEL_CCFLAGS} -I ../include $< -o $@
 
 baselib.a: ${LIBRARY_OBJECTS}
-	ar rv $@ ${LIBRARY_OBJECTS}
+	${AR} rv $@ ${LIBRARY_OBJECTS}
 
 clean:
 	rm -rf *.a *.o


### PR DESCRIPTION
Building the cross-compiler and building Basekernel with a cross-compiler should now be (mostly) platform-independent and works on macOS. On Linux (Debian 9 stretch), build-cross-compiler.sh still fails trying to configure gcc:

```
checking how to run the C++ preprocessor... /lib/cpp
configure: error: in `/tmp/tmp.Ifz6SIKmzO/gcc-8.2.0-elf-objs/gcc':
configure: error: C++ preprocessor "/lib/cpp" fails sanity check
See `config.log' for more details.
Makefile:4200: recipe for target 'configure-gcc' failed
make: *** [configure-gcc] Error 1
```