### PR TITLE
Fix kevinfs_read_dir to separate entry names with \0 instead of space.

### DIFF
--- a/kernel/kevinfs.c
+++ b/kernel/kevinfs.c
@@ -474,13 +474,11 @@ static int kevinfs_read_dir(struct fs_dirent *d, char *buffer, int buffer_len)
 	if(list) {
 		struct kevinfs_dir_record *r = list->list;
 		while(buffer_len > strlen(r->filename)) {
-			int len = strlen(r->filename);
+			int len = strlen(r->filename) + 1;
 			strcpy(buffer, r->filename);
 			buffer += len;
-			*buffer = ' ';
-			buffer++;
-			buffer_len -= len + 1;
-			total += len + 1;
+			buffer_len -= len;
+			total += len;
 
 			if(r->offset_to_next == 0)
 				break;


### PR DESCRIPTION
Fix kevinfs_read_dir to return a null-separated array of entry filenames instead of a space-separated array