### PR TITLE
Missing Function Declaration for read_nonblock in syscalls.h

### DIFF
--- a/include/library/syscalls.h
+++ b/include/library/syscalls.h
@@ -27,6 +27,7 @@ int open( const char *path, int mode, int flags );
 int object_type( int fd );
 int dup( int fd1, int fd2 );
 int read( int fd, void *data, int length );
+int read_nonblock(int fd, void *data, int length);
 int write( int fd, void *data, int length );
 int lseek( int fd, int offset, int whence );
 int close( int fd );


### PR DESCRIPTION
At some point, the function declaration for read_nonblock in syscalls.h was lost. This is a simple PR adding it back in.