### PR TITLE
Fixed up to GNU99 Standard

### DIFF
--- a/Makefile.config
+++ b/Makefile.config
@@ -1,4 +1,4 @@
-KERNEL_CCFLAGS=-Wall -c -ffreestanding -fno-pie -g
+KERNEL_CCFLAGS=-Wall -c -ffreestanding -fno-pie -g -std=gnu99
 ISOGEN=genisoimage
 
 # These settings select the native compiler,

--- a/kernel/ata.c
+++ b/kernel/ata.c
@@ -81,7 +81,7 @@ static struct list queue = { 0, 0 };
 static struct mutex ata_mutex = MUTEX_INIT;
 static int identify_in_progress = 0;
 
-static struct ata_count counters = {0};
+static struct ata_count counters = {{0}};
 
 struct ata_count ata_stats()
 {

--- a/kernel/kevinfs.c
+++ b/kernel/kevinfs.c
@@ -379,7 +379,7 @@ static int kevinfs_read_block(struct fs_dirent *d, char *buffer, uint32_t addres
 	uint32_t address = 0;
 	if (address_no >= FS_DIRECT_MAXBLOCKS) {
 		address_no -= FS_DIRECT_MAXBLOCKS;
-		struct kevinfs_indirect_block indirect_struct = {0};
+		struct kevinfs_indirect_block indirect_struct = {{0}};
 		if (kevinfs_read_data_block(kv, node->indirect_block_address, (uint8_t *) &indirect_struct) < 0) {
 			return -1;
 		}
@@ -398,7 +398,7 @@ static int kevinfs_write_data_block(struct kevinfs_dirent *kd, uint32_t address_
 	uint32_t address = 0;
 	if (address_no >= FS_DIRECT_MAXBLOCKS) {
 		address_no -= FS_DIRECT_MAXBLOCKS;
-		struct kevinfs_indirect_block indirect_struct = {0};
+		struct kevinfs_indirect_block indirect_struct ={{0}};
 		if (kevinfs_read_data_block(kv, node->indirect_block_address, (uint8_t *) &indirect_struct) < 0) {
 			return -1;
 		}
@@ -447,7 +447,7 @@ static int kevinfs_delete_dirent_or_decrement_links(struct kevinfs_dirent *kd)
 		return -1;
 	uint32_t num_blocks = node->size / FS_BLOCKSIZE + (node->size % FS_BLOCKSIZE ? 1:0);
 	if (num_blocks > FS_DIRECT_MAXBLOCKS) {
-		struct kevinfs_indirect_block indirect_struct = {0};
+		struct kevinfs_indirect_block indirect_struct = {{0}};
 		if (kevinfs_read_data_block(kd->kv, node->indirect_block_address, (uint8_t *) &indirect_struct) < 0) {
 			return 0;
 		}
@@ -562,7 +562,7 @@ static int kevinfs_internal_dirent_resize(struct kevinfs_dirent *kd, uint32_t nu
 		num_blocks -= FS_DIRECT_MAXBLOCKS;
 		if (num_blocks > FS_INDIRECT_MAXBLOCKS)
 			return -1;
-		struct kevinfs_indirect_block indirect_struct = {0};
+		struct kevinfs_indirect_block indirect_struct = {{0}};
 		if (!node->indirect_block_address) {
 			if(kevinfs_lookup_available_block(kv, &(node->indirect_block_address)) < 0) {
 				return -1;


### PR DESCRIPTION
I get a bunch of fiddly warnings when compiling on gcc 4.8.5.
I propose we set the code standard to GNU C99.
(And also fix up some nested initializer warnings.)
Does this work for everyone else?
