### PR TITLE
Fix program argument handling.

### DIFF
--- a/kernel/process.c
+++ b/kernel/process.c
@@ -477,29 +477,58 @@ int process_reap(uint32_t pid)
 	return 1;
 }
 
-void process_pass_arguments(struct process *p, const char **argv, int argc)
+/*
+process_pass_arguments set up the current process stack
+so that it contains a copy of p->args and p->args_length
+at the very top, serving as the initial arguments to the entry function:
+void entry( const char *args, int args_length );
+*/
+
+#define PUSH_INTEGER( value ) esp -= sizeof(int); *((int*)esp)=(int)(value);
+
+void process_pass_arguments( struct process *p, int argc, char **argv )
 {
-	/* Copy command line arguments */
-	struct x86_stack *s = (struct x86_stack *) p->kstack_ptr;
-	unsigned paddr;
-	pagetable_getmap(p->pagetable, PROCESS_STACK_INIT - PAGE_SIZE + 0x10, &paddr, 0);
-	char *esp = (char *) paddr + PAGE_SIZE - 0x10;
-	char *ebp = esp;
-	/* Copy each argument */
+	/* Get the default stack pointer position. */
+	char *esp = (char*) PROCESS_STACK_INIT;
+
+	/* Make a local array to keep track of user addresses. */
+	char **addr_of_argv = kmalloc(sizeof(char*)*argc);
+
+	/* For each argument, in reverse order: */
 	int i;
-	for(i = 0; i < argc; i++) {
-		ebp -= MAX_ARGV_LENGTH;
-		strncpy(ebp, argv[i], MAX_ARGV_LENGTH - 1);
+	for(i=(argc-1);i>=0;i--) {
+		/* Size is strlen plus null terminator, integer aligned. */
+		int length = strlen(argv[i])+1;
+		if(length%4) { length += (4-length%4); }
+		esp -= length;
+
+		/* Push length bytes onto the stack. */
+		memcpy(esp,argv[i],length);
+
+		/* Remember that address for later */
+		addr_of_argv[i] = esp;
 	}
-	/* Set pointers to each argument (argv) */
-	for(i = argc; i > 0; --i) {
-		ebp -= 4;
-		*((char **) (ebp)) = ((char *) (PROCESS_STACK_INIT - MAX_ARGV_LENGTH * i));
+
+	/* Push each item of argc, in reverse order. */
+	for(i=(argc-1);i>=0;i--) {
+		PUSH_INTEGER(addr_of_argv[i]);
 	}
-	/* Set argumetns for _start on the stack */
-	*((char **) (ebp - 12)) = (char *) (PROCESS_STACK_INIT - MAX_ARGV_LENGTH * argc - 4 * argc);
-	*((int *) (ebp - 8)) = argc;
-	s->esp -= (esp - ebp) + 16;
+
+	/* Keep the address of the array start. */
+	const char *addr_of_addr_of_argv = esp;
+
+	/* Push the arguments to main */
+	PUSH_INTEGER(argc);
+	PUSH_INTEGER(addr_of_addr_of_argv);
+
+	/* Final stack pointer should be below the last item. */
+	esp -= 4;
+
+	/* Set the starting stack pointer on the kstack to this new value */
+	struct x86_stack *s = (struct x86_stack *) p->kstack_ptr;
+	s->esp = (int)(esp);
+
+	kfree(addr_of_argv);
 }
 
 int process_stats(int pid, struct proc_stats *s) {

--- a/kernel/process.h
+++ b/kernel/process.h
@@ -52,7 +52,7 @@ void process_init();
 struct process *process_create();
 void process_delete(struct process *p);
 void process_launch(struct process *p);
-void process_pass_arguments(struct process *p, const char **argv, int argc);
+void process_pass_arguments(struct process *p, int argc, char **argv );
 void process_inherit(struct process *parent, struct process *child);
 
 void process_stack_reset(struct process *p, unsigned size);

--- a/kernel/syscall_handler.c
+++ b/kernel/syscall_handler.c
@@ -85,8 +85,9 @@ the memory state, then loading
 
 int sys_process_run(const char *path, const char **argv, int argc )
 {
-	/* Copy argv array into kernel memory. */
+	/* Copy argv and path into kernel memory. */
 	char **copy_argv = argv_copy(argc,argv);
+	char *copy_path = strdup(path);
 
 	/* Create the child process */
 	struct process *p = process_create();
@@ -99,7 +100,7 @@ int sys_process_run(const char *path, const char **argv, int argc )
 
 	/* Attempt to load the program image. */
 	addr_t entry;
-	int r = elf_load(p, path, &entry);
+	int r = elf_load(p, copy_path, &entry);
 	if(r >= 0) {
 		/* If load succeeded, reset stack and pass arguments */
 		process_stack_reset(p, PAGE_SIZE);
@@ -111,8 +112,9 @@ int sys_process_run(const char *path, const char **argv, int argc )
 	current->pagetable = old_pagetable;
 	pagetable_load(old_pagetable);
 
-	/* Delete the argument copy. */
+	/* Delete the argument and path copies. */
 	argv_delete(argc,copy_argv);
+	kfree(copy_path);
 
 	/* If any error happened, return in the context of the parent */
 	if(r < 0) {

--- a/user/exctst.c
+++ b/user/exctst.c
@@ -1,11 +1,20 @@
 #include "library/syscalls.h"
 #include "library/string.h"
 
-int main(const char *argv[], int argc)
+int main()
 {
-	printf("Testing exec.  Exec'ing saver.exe.\n");
-	const char *args[] = { "saver.exe" };
-	process_exec("saver.exe", args, 1);
-	printf("This shouldn't print.\n");
+	int pid = process_fork();
+
+	if (pid == 0) {
+		printf("hello world, I am the child %d.\n", process_self());
+		const char *args[] = { "snake.exe" };
+		process_exec("snake.exe", args, 1);
+	} else {
+		printf("hello world, I am the parent %d.\n", process_self());
+		struct process_info info;
+		process_wait(&info, -1);
+		process_reap(info.pid);
+	}
+
 	return 0;
 }


### PR DESCRIPTION
Because the arguments must by copied from one address space to another,
the only safe way to do it is to first duplicate into kernel space,
and then copy into the child process when its address space is active.