### PR TITLE
Make console text white

### DIFF
--- a/kernel/console.c
+++ b/kernel/console.c
@@ -20,7 +20,7 @@ struct console_device {
 };
 
 struct graphics_color bgcolor = { 0, 0, 0 };
-struct graphics_color fgcolor = { 100, 100, 255 };
+struct graphics_color fgcolor = { 255, 255, 255 };
 struct console_device console = { {0} };
 
 static void console_reset(struct console_device *d)


### PR DESCRIPTION
Small change to make the console text white instead of blue for improved readability