### PR TITLE
Remove '\f' from exception print statement

### DIFF
--- a/kernel/interrupt.c
+++ b/kernel/interrupt.c
@@ -68,7 +68,7 @@ static void unknown_exception(int i, int code)
 			return;
 		}
 	} else {
-		console_printf("\finterrupt: exception %d: %s (code %x)\n", i, exception_names[i], code);
+		console_printf("interrupt: exception %d: %s (code %x)\n", i, exception_names[i], code);
 		process_dump(current);
 	}
 


### PR DESCRIPTION
This stops interrupts from automatically clearing the console screen to allow for easier debugging