### PR TITLE
Add -iso-level 3 argument to ISO generate command

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -27,11 +27,10 @@ image: kernel/basekernel.img $(USER_PROGRAMS)
 	cp $(USER_PROGRAMS) image/bin
 
 basekernel.iso: image
-	${ISOGEN} -input-charset utf-8 -J -R -o $@ -b boot/basekernel.img image
+	${ISOGEN} -input-charset utf-8 -iso-level 3 -J -R -o $@ -b boot/basekernel.img image
 
 clean:
 	rm -rf basekernel.iso image
 	cd kernel && make clean
 	cd library && make clean
 	cd user && make clean
-


### PR DESCRIPTION
Fixes #171 by setting the iso-level parameter for genisoimage/mkisofs, so that the 8.3 filename length limit is no longer imposed. Essentially relaxes the ISO-9660 conformance level.