### PR TITLE
Object type to string

### DIFF
--- a/include/kernel/ktypes.h
+++ b/include/kernel/ktypes.h
@@ -1,0 +1,10 @@
+#ifndef KTYPES_H
+#define KTYPES_H
+typedef enum {
+	KOBJECT_INVALID = 0,
+	KOBJECT_FILE,
+	KOBJECT_DEVICE,
+	KOBJECT_GRAPHICS,
+	KOBJECT_PIPE
+} kobject_type;
+#endif

--- a/include/library/objno.h
+++ b/include/library/objno.h
@@ -1,0 +1,9 @@
+#ifndef OBJNO_H
+#define OBJNO_H
+
+static const char KOBJECT_INVALID_STRING[] = "Invalid";
+static const char KOBJECT_FILE_STRING[] = "File";
+static const char KOBJECT_DEVICE_STRING[] = "Device";
+static const char KOBJECT_GRAPHICS_STRING[] = "Graphics";
+
+#endif

--- a/include/library/objno.h
+++ b/include/library/objno.h
@@ -1,9 +1,6 @@
 #ifndef OBJNO_H
 #define OBJNO_H
 
-static const char KOBJECT_INVALID_STRING[] = "Invalid";
-static const char KOBJECT_FILE_STRING[] = "File";
-static const char KOBJECT_DEVICE_STRING[] = "Device";
-static const char KOBJECT_GRAPHICS_STRING[] = "Graphics";
+const char *strerror(int err_code);
 
 #endif

--- a/kernel/kobject.h
+++ b/kernel/kobject.h
@@ -10,6 +10,7 @@
 #include "fs.h"
 #include "device.h"
 #include "graphics.h"
+#include "kernel/ktypes.h"
 #include "pipe.h"
 
 struct kobject {
@@ -19,13 +20,7 @@ struct kobject {
 		struct graphics *graphics;
 		struct pipe *pipe;
 	} data;
-	enum {
-		KOBJECT_INVALID = 0,
-		KOBJECT_FILE,
-		KOBJECT_DEVICE,
-		KOBJECT_GRAPHICS,
-		KOBJECT_PIPE
-	} type;
+	kobject_type type;
 	int refcount;
 	int offset;
 };

--- a/library/Makefile
+++ b/library/Makefile
@@ -1,6 +1,6 @@
 include ../Makefile.config
 
-LIBRARY_OBJECTS=syscall.o syscalls.o string.o user-io.o malloc.o
+LIBRARY_OBJECTS=objno.o syscall.o syscalls.o string.o user-io.o malloc.o
 
 all: user-start.o baselib.a
 

--- a/library/objno.c
+++ b/library/objno.c
@@ -1,0 +1,19 @@
+#include "kernel/ktypes.h"
+#include "library/objno.h"
+#include "library/string.h"
+
+const char *strerror(int err_code)
+{
+	if(err_code == KOBJECT_INVALID) {
+		return KOBJECT_INVALID_STRING;
+	}
+	if(err_code == KOBJECT_FILE) {
+		return KOBJECT_FILE_STRING;
+	}
+	if(err_code == KOBJECT_DEVICE) {
+		return KOBJECT_DEVICE_STRING;
+	}
+	if(err_code == KOBJECT_GRAPHICS) {
+		return KOBJECT_GRAPHICS_STRING;
+	}
+}

--- a/library/objno.c
+++ b/library/objno.c
@@ -2,18 +2,21 @@
 #include "library/objno.h"
 #include "library/string.h"
 
+static const char KOBJECT_INVALID_STRING[] = "Invalid";
+static const char KOBJECT_FILE_STRING[] = "File";
+static const char KOBJECT_DEVICE_STRING[] = "Device";
+static const char KOBJECT_GRAPHICS_STRING[] = "Graphics";
+
 const char *strerror(int err_code)
 {
-	if(err_code == KOBJECT_INVALID) {
-		return KOBJECT_INVALID_STRING;
-	}
-	if(err_code == KOBJECT_FILE) {
-		return KOBJECT_FILE_STRING;
-	}
-	if(err_code == KOBJECT_DEVICE) {
-		return KOBJECT_DEVICE_STRING;
-	}
-	if(err_code == KOBJECT_GRAPHICS) {
-		return KOBJECT_GRAPHICS_STRING;
+	switch(err_code) {
+		case KOBJECT_INVALID:
+			return KOBJECT_INVALID_STRING;
+		case KOBJECT_FILE:
+			return KOBJECT_FILE_STRING;
+		case KOBJECT_DEVICE:
+			return KOBJECT_DEVICE_STRING;
+		case KOBJECT_GRAPHICS:
+			return KOBJECT_GRAPHICS_STRING;
 	}
 }


### PR DESCRIPTION
Exposed kobject types enum to #include space and implemented library function for converting to string.