### PR TITLE
Switch Makefile.config to default to using the cross-compiler

### DIFF
--- a/Makefile.config
+++ b/Makefile.config
@@ -4,15 +4,15 @@ ISOGEN=genisoimage
 # These settings select the native compiler,
 # which is likely to work on native linux-x86.
 #
-CC=gcc -m32
-LD=ld -melf_i386
-AR=ar
-OBJCOPY=objcopy
+# CC=gcc -m32
+# LD=ld -melf_i386
+# AR=ar
+# OBJCOPY=objcopy
 
 # If you are compiling from another platform,
 # then use the script build-cross-compiler.sh
 # add cross/bin to your path, and uncomment these lines:
-#CC=i686-elf-gcc
-#LD=i686-elf-ld
-#AR=i686-elf-ar
-#OBJCOPY=i686-elf-objcopy
+CC=i686-elf-gcc
+LD=i686-elf-ld
+AR=i686-elf-ar
+OBJCOPY=i686-elf-objcopy


### PR DESCRIPTION
Simple change to Makefile.config to default to using the cross-compiler for consistency across machines (using the native Linux toolchain still left as an option)