### PR TITLE
Unified Buffer Cache

### DIFF
--- a/kernel/Makefile
+++ b/kernel/Makefile
@@ -1,6 +1,6 @@
 include ../Makefile.config
 
-KERNEL_OBJECTS=kernelcore.o main.o console.o memory.o keyboard.o mouse.o clock.o interrupt.o kmalloc.o pic.o ata.o cdromfs.o string.o bitmap.o graphics.o font.o syscall_handler.o process.o mutex.o list.o pagetable.o rtc.o kshell.o fs.o kevinfs.o hash_set.o kevinfs_test.o serial.o elf.o device.o kobject.o buffer.o pipe.o bcache.o
+KERNEL_OBJECTS=kernelcore.o main.o console.o memory.o keyboard.o mouse.o clock.o interrupt.o kmalloc.o pic.o ata.o cdromfs.o string.o bitmap.o graphics.o font.o syscall_handler.o process.o mutex.o list.o pagetable.o rtc.o kshell.o fs.o kevinfs.o hash_set.o kevinfs_test.o serial.o elf.o device.o kobject.o pipe.o bcache.o
 
 basekernel.img: bootblock kernel
 	cat bootblock kernel /dev/zero | head -c 1474560 > basekernel.img

--- a/kernel/Makefile
+++ b/kernel/Makefile
@@ -1,6 +1,6 @@
 include ../Makefile.config
 
-KERNEL_OBJECTS=kernelcore.o main.o console.o memory.o keyboard.o mouse.o clock.o interrupt.o kmalloc.o pic.o ata.o cdromfs.o string.o bitmap.o graphics.o font.o syscall_handler.o process.o mutex.o list.o pagetable.o rtc.o kshell.o fs.o kevinfs.o hash_set.o kevinfs_test.o serial.o elf.o device.o kobject.o buffer.o pipe.o
+KERNEL_OBJECTS=kernelcore.o main.o console.o memory.o keyboard.o mouse.o clock.o interrupt.o kmalloc.o pic.o ata.o cdromfs.o string.o bitmap.o graphics.o font.o syscall_handler.o process.o mutex.o list.o pagetable.o rtc.o kshell.o fs.o kevinfs.o hash_set.o kevinfs_test.o serial.o elf.o device.o kobject.o buffer.o pipe.o bcache.o
 
 basekernel.img: bootblock kernel
 	cat bootblock kernel /dev/zero | head -c 1474560 > basekernel.img

--- a/kernel/bcache.c
+++ b/kernel/bcache.c
@@ -54,10 +54,6 @@ void bcache_entry_clean( struct bcache_entry *e )
 
 }
 
-void bcache_init()
-{
-}
-
 void bcache_trim()
 {
 	struct bcache_entry *e;

--- a/kernel/bcache.c
+++ b/kernel/bcache.c
@@ -1,0 +1,145 @@
+
+#include "bcache.h"
+#include "list.h"
+#include "memory.h"
+#include "kmalloc.h"
+#include "string.h"
+#include "kernel/error.h"
+
+struct bcache_entry {
+	struct list_node node;
+	struct device *device;
+	int block;
+	int dirty;
+	char *data;
+};
+
+static struct list cache = LIST_INIT;
+static int max_cache_size = 100;
+
+struct bcache_entry * bcache_entry_create( struct device *device, int block )
+{
+	struct bcache_entry *e = kmalloc(sizeof(*e));
+	if(!e) return 0;
+
+	e->device = device;
+	e->block = block;
+	e->data = memory_alloc_page(1);
+	if(!e->data) {
+		kfree(e);
+		return 0;
+	}
+
+	return e;
+
+}
+
+void bcache_entry_delete( struct bcache_entry *e )
+{
+	if(e) {
+		if(e->data) memory_free_page(e->data);
+		kfree(e);
+	}
+}
+
+void bcache_entry_clean( struct bcache_entry *e )
+{
+	if(e->dirty) {
+		device_write(e->device,e->data,1,e->block);
+		// XXX deal with failure!
+		e->dirty = 0;
+	}
+
+}
+
+void bcache_init()
+{
+}
+
+void bcache_trim()
+{
+	struct bcache_entry *e;
+
+	while(list_size(&cache)>max_cache_size) {
+		e = (struct bcache_entry *) list_pop_tail(&cache);
+		bcache_entry_clean(e);
+		bcache_entry_delete(e);
+	}
+}
+
+struct bcache_entry * bcache_find( struct device *device, int block )
+{
+	struct list_node *n;
+	struct bcache_entry *e;
+
+	for(n=cache.head;n;n=n->next) {
+		e = (struct bcache_entry *)n;
+		if(e->device==device && e->block==block) {
+			return e;
+		}
+	}
+
+	return 0;
+}
+
+struct bcache_entry * bcache_find_or_create( struct device *device, int block )
+{
+	struct bcache_entry *e = bcache_find(device,block);
+	if(!e) {
+		e = bcache_entry_create(device,block);
+		if(!e) return 0;
+		list_push_head(&cache,&e->node);
+	}
+
+	bcache_trim();
+
+	return e;
+}
+
+int bcache_read( struct device *device, char *data, int block )
+{
+	struct bcache_entry *e = bcache_find_or_create(device,block);
+	if(!e) return KERROR_NO_MEMORY;
+
+	int result = device_read(device,e->data,1,block);
+
+	if(result>0) {
+		memcpy(data,e->data,device_block_size(device));
+	} else {
+		list_remove(&e->node);
+		bcache_entry_delete(e);
+	}
+
+	return result;
+}
+
+int bcache_write( struct device *device, const char *data, int block )
+{
+	struct bcache_entry *e = bcache_find_or_create(device,block);
+	if(!e) return KERROR_NO_MEMORY;
+
+	memcpy(e->data,data,device_block_size(device));
+	e->dirty = 1;
+
+	return 1;
+}
+
+void bcache_flush_block( struct device *device, int block )
+{
+	struct bcache_entry *e;
+	e = bcache_find(device,block);
+	if(e) bcache_entry_clean(e);
+}
+
+void bcache_flush_device( struct device *device )
+{
+	struct list_node *n;
+	struct bcache_entry *e;
+
+	for(n=cache.head;n;n=n->next) {
+		e = (struct bcache_entry *) n;
+		if(e->device==device) {
+			bcache_entry_clean(e);
+		}
+	}
+}

--- a/kernel/bcache.h
+++ b/kernel/bcache.h
@@ -14,4 +14,14 @@ int  bcache_write_block( struct device *d, const char *data, int block );
 void bcache_flush_block( struct device *d, int block );
 void bcache_flush_device( struct device *d  );
 
+struct bcache_stats {
+	unsigned read_hits;
+	unsigned read_misses;
+	unsigned write_hits;
+	unsigned write_misses;
+	unsigned writebacks;
+};
+
+void bcache_get_stats( struct bcache_stats *s );
+
 #endif

--- a/kernel/bcache.h
+++ b/kernel/bcache.h
@@ -1,0 +1,14 @@
+#ifndef BCACHE_H
+#define BCACHE_H
+
+#include "device.h"
+
+void bcache_init();
+
+int  bcache_read( struct device *d, char *data, int block );
+int  bcache_write( struct device *d, const char *data, int block );
+
+void bcache_flush_block( struct device *d, int block );
+void bcache_flush_device( struct device *d  );
+
+#endif

--- a/kernel/bcache.h
+++ b/kernel/bcache.h
@@ -3,8 +3,6 @@
 
 #include "device.h"
 
-void bcache_init();
-
 int  bcache_read( struct device *d, char *data, int blocks, int offset );
 int  bcache_write( struct device *d, const char *data, int blocks, int offset );
 

--- a/kernel/bcache.h
+++ b/kernel/bcache.h
@@ -5,8 +5,11 @@
 
 void bcache_init();
 
-int  bcache_read( struct device *d, char *data, int block );
-int  bcache_write( struct device *d, const char *data, int block );
+int  bcache_read( struct device *d, char *data, int blocks, int offset );
+int  bcache_write( struct device *d, const char *data, int blocks, int offset );
+
+int  bcache_read_block( struct device *d, char *data, int block );
+int  bcache_write_block( struct device *d, const char *data, int block );
 
 void bcache_flush_block( struct device *d, int block );
 void bcache_flush_device( struct device *d  );

--- a/kernel/cdromfs.c
+++ b/kernel/cdromfs.c
@@ -13,6 +13,7 @@ See the file LICENSE for details.
 #include "memory.h"
 #include "fs.h"
 #include "device.h"
+#include "bcache.h"
 #include "cdromfs.h"
 #include "kernel/syscall.h"
 
@@ -55,7 +56,7 @@ static char *cdrom_dirent_load(struct fs_dirent *d)
 	if(!data)
 		return 0;
 
-	device_read(cdd->volume->device, data, nsectors, cdd->sector);
+	bcache_read(cdd->volume->device, data, nsectors, cdd->sector);
 	// XXX check result
 
 	return data;
@@ -229,7 +230,7 @@ static struct fs_volume *cdrom_volume_open(int unit)
 	for(j = 0; j < 16; j++) {
 		printf("cdromfs: checking volume %d\n", j);
 
-		device_read(device, d, 1, j + 16);
+		bcache_read(device, (char*)d, 1, j + 16);
 		// XXX check reuslt
 
 		if(strncmp(d->magic, "CD001", 5))

--- a/kernel/console.c
+++ b/kernel/console.c
@@ -132,7 +132,6 @@ struct device *console_init(struct graphics *g)
 	console.device.block_size = 1;
 	console.device.write = console_device_write;
 	console_reset(&console);
-	console.device.buffer = 0;
 	console_putstring("\nconsole: initialized\n");
 	return (struct device *) &console;
 }
@@ -147,7 +146,6 @@ struct device *console_create(struct graphics *g)
 	struct console_device *c = kmalloc(sizeof(*c));
 	c->gx = g;
 	c->device.block_size = 1;
-	c->device.buffer = 0;
 	c->device.write = console_device_write_debug;
 	console_reset(c);
 	return (struct device *) c;

--- a/kernel/device.c
+++ b/kernel/device.c
@@ -110,3 +110,8 @@ int device_write(struct device *d, const void *buffer, int size, int offset)
 	}
 	return -1;
 }
+
+int device_block_size( struct device *d )
+{
+	return d->block_size;
+}

--- a/kernel/device.c
+++ b/kernel/device.c
@@ -5,13 +5,13 @@
  */
 
 
-#include "kernel/types.h"
 #include "device.h"
 #include "string.h"
 #include "ata.h"
 #include "cdromfs.h"
 #include "keyboard.h"
-#include "buffer.h"
+#include "kernel/types.h"
+#include "kernel/error.h"
 
 #define ATA_DEVICE_COUNT   4
 #define ATAPI_DEVICE_COUNT 4
@@ -19,19 +19,19 @@
 static struct device ata_devices[ATA_DEVICE_COUNT] = { {0} };
 static struct device atapi_devices[ATAPI_DEVICE_COUNT] = { {0} };
 
-int ata_device_read(struct device *d, void *buffer, int nblocks, int offset)
+int ata_device_read(struct device *d, void *data, int nblocks, int offset)
 {
-	return ata_read(d->unit, buffer, nblocks, offset);
+	return ata_read(d->unit, data, nblocks, offset);
 }
 
-int ata_device_write(struct device *d, const void *buffer, int nblocks, int offset)
+int ata_device_write(struct device *d, const void *data, int nblocks, int offset)
 {
-	return ata_write(d->unit, buffer, nblocks, offset);
+	return ata_write(d->unit, data, nblocks, offset);
 }
 
-int atapi_device_read(struct device *d, void *buffer, int nblocks, int offset)
+int atapi_device_read(struct device *d, void *data, int nblocks, int offset)
 {
-	return atapi_read(d->unit, buffer, nblocks, offset);
+	return atapi_read(d->unit, data, nblocks, offset);
 }
 
 void device_init()
@@ -39,16 +39,15 @@ void device_init()
 	int i;
 	for(i = 0; i < ATAPI_DEVICE_COUNT; i++) {
 		atapi_devices[i].read = atapi_device_read;
+		atapi_devices[i].write = 0;
 		atapi_devices[i].unit = i;
 		atapi_devices[i].block_size = CDROM_BLOCK_SIZE;
-		atapi_devices[i].buffer = 0;
 	}
 	for(i = 0; i < ATA_DEVICE_COUNT; i++) {
 		ata_devices[i].read = ata_device_read;
 		ata_devices[i].write = ata_device_write;
 		ata_devices[i].unit = i;
 		ata_devices[i].block_size = ATA_BLOCKSIZE;
-		ata_devices[i].buffer = buffer_init(ATA_BLOCKSIZE);
 	}
 }
 
@@ -68,47 +67,31 @@ struct device *device_open(char *name, int unit)
 	return 0;
 }
 
-int device_read(struct device *d, void *buffer, int size, int offset)
+int device_read(struct device *d, void *data, int size, int offset)
 {
 	if(d->read) {
-		if(!d->buffer || buffer_read(d->buffer, offset, buffer) < 0) {
-			int ret = d->read(d, buffer, size, offset);
-			if(ret == 1 && d->buffer)
-				buffer_add(d->buffer, offset, buffer);
-			return 1;
-		}
-		return 1;
+		return d->read(d,data,size,offset);
+	} else {
+		return KERROR_NOT_SUPPORTED;
 	}
-	return -1;
 }
 
-int device_read_nonblock(struct device *d, void *buffer, int size, int offset)
+int device_read_nonblock(struct device *d, void *data, int size, int offset)
 {
 	if(d->read_nonblock) {
-		if(!d->buffer || buffer_read(d->buffer, offset, buffer) < 0) {
-			int ret = d->read_nonblock(d, buffer, size, offset);
-			if(ret == 1 && d->buffer)
-				buffer_add(d->buffer, offset, buffer);
-			return 1;
-		}
-		return 1;
+		return d->read_nonblock(d,data,size,offset);
+	} else {
+		return KERROR_NOT_SUPPORTED;
 	}
-	return -1;
 }
 
-int device_write(struct device *d, const void *buffer, int size, int offset)
+int device_write(struct device *d, const void *data, int size, int offset)
 {
 	if(d->write) {
-		if(d->buffer) {
-			buffer_delete(d->buffer, offset);
-		}
-		int ret = d->write(d, buffer, size, offset);
-		if(ret == 1 && d->buffer) {
-			buffer_add(d->buffer, offset, buffer);
-		}
-		return ret;
+		return d->write(d,data,size,offset);
+	} else {
+		return KERROR_NOT_SUPPORTED;
 	}
-	return -1;
 }
 
 int device_block_size( struct device *d )

--- a/kernel/device.h
+++ b/kernel/device.h
@@ -8,9 +8,6 @@
 #define DEVICE_H
 
 #include "kernel/types.h"
-#include "graphics.h"
-#include "device.h"
-#include "buffer.h"
 
 struct device {
 	int (*read) (struct device * d, void *buffer, int size, int offset);
@@ -18,11 +15,10 @@ struct device {
 	int (*write) (struct device * d, const void *buffer, int size, int offset);
 	int unit;
 	int block_size;
-	int alloced;
-	struct buffer *buffer;
 };
 
 void device_init();
+
 struct device *device_open(char *type, int unit);
 int device_read(struct device *d, void *buffer, int size, int offset);
 int device_read_nonblock(struct device *d, void *buffer, int size, int offset);

--- a/kernel/device.h
+++ b/kernel/device.h
@@ -27,5 +27,6 @@ struct device *device_open(char *type, int unit);
 int device_read(struct device *d, void *buffer, int size, int offset);
 int device_read_nonblock(struct device *d, void *buffer, int size, int offset);
 int device_write(struct device *d, const void *buffer, int size, int offset);
+int device_block_size( struct device *d );
 
 #endif

--- a/kernel/kevinfs.c
+++ b/kernel/kevinfs.c
@@ -75,15 +75,17 @@ static void kevinfs_print_dir_record_list(struct kevinfs_dir_record_list *l)
 
 int kevinfs_ata_read_block(struct device *device, uint32_t index, void *buffer)
 {
-	uint32_t num_blocks = FS_BLOCKSIZE / ATA_BLOCKSIZE;
-	index = index * FS_BLOCKSIZE / ATA_BLOCKSIZE;
+	int factor = FS_BLOCKSIZE / ATA_BLOCKSIZE;
+	uint32_t num_blocks = factor;
+	index = index * factor;
 	return bcache_read(device, buffer, num_blocks, index) ? FS_BLOCKSIZE : -1;
 }
 
 int kevinfs_ata_write_block(struct device *device, uint32_t index, const void *buffer)
 {
+	int factor = FS_BLOCKSIZE / ATA_BLOCKSIZE;
 	uint32_t num_blocks = FS_BLOCKSIZE / ATA_BLOCKSIZE;
-	index = index * FS_BLOCKSIZE / ATA_BLOCKSIZE;
+	index = index * factor;
 	return bcache_write(device, buffer, num_blocks, index) ? FS_BLOCKSIZE : -1;
 }
 

--- a/kernel/kevinfs.c
+++ b/kernel/kevinfs.c
@@ -84,7 +84,7 @@ int kevinfs_ata_read_block(struct device *device, uint32_t index, void *buffer)
 int kevinfs_ata_write_block(struct device *device, uint32_t index, const void *buffer)
 {
 	int factor = FS_BLOCKSIZE / ATA_BLOCKSIZE;
-	uint32_t num_blocks = FS_BLOCKSIZE / ATA_BLOCKSIZE;
+	uint32_t num_blocks = factor;
 	index = index * factor;
 	return bcache_write(device, buffer, num_blocks, index) ? FS_BLOCKSIZE : -1;
 }

--- a/kernel/kshell.c
+++ b/kernel/kshell.c
@@ -15,6 +15,7 @@
 #include "syscall_handler.h"
 #include "clock.h"
 #include "kernelcore.h"
+#include "bcache.h"
 
 static int kshell_mount(int unit, const char *fs_type)
 {
@@ -222,8 +223,15 @@ static int kshell_execute(const char **argv, int argc)
 		printf("%d-%d-%d %d:%d:%d\n", time.year, time.month, time.day, time.hour, time.minute, time.second);
 	} else if(!strcmp(cmd, "reboot")) {
 		reboot();
+	} else if(!strcmp(cmd, "bcache_stats")) {
+		struct bcache_stats stats;
+		bcache_get_stats(&stats);
+		printf("%d rhit %d rmiss %d whit %d wmiss %d wback\n",
+			stats.read_hits,stats.read_misses,
+			stats.write_hits,stats.write_misses,
+			stats.writebacks);
 	} else if(!strcmp(cmd, "help")) {
-		printf("Kernel Shell Commands:\nrun <path> <args>\nstart <path> <args>\nkill <pid>\nreap <pid>\nwait\nlist\nmount <device> <fstype>\nformat <device> <fstype\nchdir <path>\nmkdir <path>\nrmdir <path>time\n\nreboot\nhelp\n\n");
+		printf("Kernel Shell Commands:\nrun <path> <args>\nstart <path> <args>\nkill <pid>\nreap <pid>\nwait\nlist\nmount <device> <fstype>\nformat <device> <fstype\nchdir <path>\nmkdir <path>\nrmdir <path>time\nbcache_stats\nreboot\nhelp\n\n");
 	} else {
 		printf("%s: command not found\n", argv[0]);
 	}

--- a/kernel/list.c
+++ b/kernel/list.c
@@ -5,6 +5,7 @@ See the file LICENSE for details.
 */
 
 #include "list.h"
+
 void list_push_head(struct list *list, struct list_node *node)
 {
 	node->next = list->head;
@@ -16,6 +17,7 @@ void list_push_head(struct list *list, struct list_node *node)
 	if(!list->tail)
 		list->tail = node;
 	node->list = list;
+	list->size++;
 }
 
 void list_push_tail(struct list *list, struct list_node *node)
@@ -29,6 +31,7 @@ void list_push_tail(struct list *list, struct list_node *node)
 	if(!list->head)
 		list->head = node;
 	node->list = list;
+	list->size++;
 }
 
 void list_push_priority(struct list *list, struct list_node *node, int pri)
@@ -51,6 +54,7 @@ void list_push_priority(struct list *list, struct list_node *node, int pri)
 			}
 			n->prev = node;
 			node->list = list;
+			list->size++;
 			return;
 		}
 		i++;
@@ -69,6 +73,7 @@ struct list_node *list_pop_head(struct list *list)
 			list->tail = 0;
 		result->next = result->prev = 0;
 		result->list = 0;
+		list->size--;
 	}
 	return result;
 }
@@ -84,6 +89,7 @@ struct list_node *list_pop_tail(struct list *list)
 			list->head = 0;
 		result->next = result->prev = 0;
 		result->list = 0;
+		list->size--;
 	}
 	return result;
 }
@@ -104,4 +110,10 @@ void list_remove(struct list_node *node)
 	node->prev->next = node->next;
 	node->next = node->prev = 0;
 	node->list = 0;
+	node->list->size--;
+}
+
+int list_size( struct list *list )
+{
+	return list->size;
 }

--- a/kernel/list.h
+++ b/kernel/list.h
@@ -13,6 +13,7 @@ struct list_node;
 struct list {
 	struct list_node *head;
 	struct list_node *tail;
+	int size;
 };
 
 struct list_node {
@@ -30,5 +31,6 @@ void list_push_priority(struct list *list, struct list_node *node, int pri);
 struct list_node *list_pop_head(struct list *list);
 struct list_node *list_pop_tail(struct list *list);
 void list_remove(struct list_node *n);
+int  list_size(struct list *list);
 
 #endif


### PR DESCRIPTION
First pass at creating a unified buffer cache layer above the device abstraction.
`cdromfs` is now routed through `bcache` but `kevinfs` does direct access right now.
Waiting on fixes #186 before hooking up kevinfs.
