### PR TITLE
Improve Reference Counting

### DIFF
--- a/kernel/fs.c
+++ b/kernel/fs.c
@@ -72,14 +72,14 @@ int fs_volume_close(struct fs_volume *v)
 		return KERROR_NOT_IMPLEMENTED;
 
 	v->refcount--;
-	if(v->refcount <= 0) {
+	if(v->refcount==0) {
 		v->fs->ops->volume_close(v);
 		bcache_flush_device(v->device);
 		device_close(v->device);
 		kfree(v);
 	}
 
-	return -1;
+	return 0;
 }
 
 struct fs_dirent *fs_volume_root(struct fs_volume *v)
@@ -159,7 +159,7 @@ int fs_dirent_close(struct fs_dirent *d)
 		return KERROR_NOT_IMPLEMENTED;
 
 	d->refcount--;
-	if(d->refcount <= 0) {
+	if(d->refcount==0) {
 		ops->close(d);
 		// This close is paired with the addref in fs_dirent_lookup
 		fs_volume_close(d->volume);

--- a/kernel/graphics.c
+++ b/kernel/graphics.c
@@ -1,5 +1,5 @@
 /*
-opyright (C) 2016 The University of Notre Dame
+Copyright (C) 2016 The University of Notre Dame
 This software is distributed under the GNU General Public License.
 See the file LICENSE for details.
 */
@@ -16,11 +16,18 @@ See the file LICENSE for details.
 
 #define FACTOR 256
 
+struct graphics_clip {
+	uint32_t x;
+	uint32_t y;
+	uint32_t w;
+	uint32_t h;
+};
+
 struct graphics {
 	struct bitmap *bitmap;
 	struct graphics_color fgcolor;
 	struct graphics_color bgcolor;
-	struct clip clip;
+	struct graphics_clip clip;
 	struct graphics *parent;
 	int refcount;
 };

--- a/kernel/graphics.c
+++ b/kernel/graphics.c
@@ -130,12 +130,12 @@ int graphics_write(struct graphics *g, struct graphics_command *command)
 	return 0;
 }
 
-int32_t graphics_width(struct graphics * g)
+uint32_t graphics_width(struct graphics * g)
 {
 	return g->clip.w;
 }
 
-int32_t graphics_height(struct graphics * g)
+uint32_t graphics_height(struct graphics * g)
 {
 	return g->clip.h;
 }
@@ -150,7 +150,7 @@ void graphics_bgcolor(struct graphics *g, struct graphics_color c)
 	g->bgcolor = c;
 }
 
-int graphics_clip(struct graphics *g, int32_t x, int32_t y, int32_t w, int32_t h)
+int graphics_clip(struct graphics *g, int x, int y, int w, int h)
 {
 	// Clip values may not be negative
 	if(x<0 || y<0 || w<0 || h<0) return 0;
@@ -173,7 +173,7 @@ int graphics_clip(struct graphics *g, int32_t x, int32_t y, int32_t w, int32_t h
 	return 1;
 }
 
-static inline void plot_pixel(struct bitmap *b, int32_t x, int32_t y, struct graphics_color c)
+static inline void plot_pixel(struct bitmap *b, int x, int y, struct graphics_color c)
 {
 	uint8_t *v = b->data + (b->width * y + x) * 3;
 	if(c.a == 0) {
@@ -189,7 +189,7 @@ static inline void plot_pixel(struct bitmap *b, int32_t x, int32_t y, struct gra
 	}
 }
 
-void graphics_rect(struct graphics *g, int32_t x, int32_t y, int32_t w, int32_t h)
+void graphics_rect(struct graphics *g, int x, int y, int w, int h)
 {
 	int i, j;
 
@@ -205,7 +205,7 @@ void graphics_rect(struct graphics *g, int32_t x, int32_t y, int32_t w, int32_t 
 	}
 }
 
-void graphics_clear(struct graphics *g, int32_t x, int32_t y, int32_t w, int32_t h)
+void graphics_clear(struct graphics *g, int x, int y, int w, int h)
 {
 	int i, j;
 
@@ -221,7 +221,7 @@ void graphics_clear(struct graphics *g, int32_t x, int32_t y, int32_t w, int32_t
 	}
 }
 
-static inline void graphics_line_vert(struct graphics *g, int32_t x, int32_t y, int32_t w, int32_t h)
+static inline void graphics_line_vert(struct graphics *g, int x, int y, int w, int h)
 {
 	do {
 		plot_pixel(g->bitmap, x, y, g->fgcolor);
@@ -230,10 +230,10 @@ static inline void graphics_line_vert(struct graphics *g, int32_t x, int32_t y, 
 	} while(h > 0);
 }
 
-static inline void graphics_line_q1(struct graphics *g, int32_t x, int32_t y, int32_t w, int32_t h)
+static inline void graphics_line_q1(struct graphics *g, int x, int y, int w, int h)
 {
-	int32_t slope = FACTOR * w / h;
-	int32_t counter = 0;
+	int slope = FACTOR * w / h;
+	int counter = 0;
 
 	do {
 		plot_pixel(g->bitmap, x, y, g->fgcolor);
@@ -248,10 +248,10 @@ static inline void graphics_line_q1(struct graphics *g, int32_t x, int32_t y, in
 	} while(h > 0);
 }
 
-static inline void graphics_line_q2(struct graphics *g, int32_t x, int32_t y, int32_t w, int32_t h)
+static inline void graphics_line_q2(struct graphics *g, int x, int y, int w, int h)
 {
-	int32_t slope = FACTOR * h / w;
-	int32_t counter = 0;
+	int slope = FACTOR * h / w;
+	int counter = 0;
 
 	do {
 		plot_pixel(g->bitmap, x, y, g->fgcolor);
@@ -266,10 +266,10 @@ static inline void graphics_line_q2(struct graphics *g, int32_t x, int32_t y, in
 	} while(w > 0);
 }
 
-static inline void graphics_line_q3(struct graphics *g, int32_t x, int32_t y, int32_t w, int32_t h)
+static inline void graphics_line_q3(struct graphics *g, int x, int y, int w, int h)
 {
-	int32_t slope = -FACTOR * h / w;
-	int32_t counter = 0;
+	int slope = -FACTOR * h / w;
+	int counter = 0;
 
 	do {
 		plot_pixel(g->bitmap, x, y, g->fgcolor);
@@ -284,10 +284,10 @@ static inline void graphics_line_q3(struct graphics *g, int32_t x, int32_t y, in
 	} while(w > 0);
 }
 
-static inline void graphics_line_q4(struct graphics *g, int32_t x, int32_t y, int32_t w, int32_t h)
+static inline void graphics_line_q4(struct graphics *g, int x, int y, int w, int h)
 {
-	int32_t slope = -FACTOR * w / h;
-	int32_t counter = 0;
+	int slope = -FACTOR * w / h;
+	int counter = 0;
 
 	do {
 		plot_pixel(g->bitmap, x, y, g->fgcolor);
@@ -302,7 +302,7 @@ static inline void graphics_line_q4(struct graphics *g, int32_t x, int32_t y, in
 	} while(h > 0);
 }
 
-static inline void graphics_line_hozo(struct graphics *g, int32_t x, int32_t y, int32_t w, int32_t h)
+static inline void graphics_line_hozo(struct graphics *g, int x, int y, int w, int h)
 {
 	do {
 		plot_pixel(g->bitmap, x, y, g->fgcolor);
@@ -311,7 +311,7 @@ static inline void graphics_line_hozo(struct graphics *g, int32_t x, int32_t y, 
 	} while(w > 0);
 }
 
-void graphics_line(struct graphics *g, int32_t x, int32_t y, int32_t w, int32_t h)
+void graphics_line(struct graphics *g, int x, int y, int w, int h)
 {
 	if(w < 0) {
 		x = x + w;
@@ -342,7 +342,7 @@ void graphics_line(struct graphics *g, int32_t x, int32_t y, int32_t w, int32_t 
 	}
 }
 
-void graphics_bitmap(struct graphics *g, int32_t x, int32_t y, int32_t width, int32_t height, uint8_t * data)
+void graphics_bitmap(struct graphics *g, int x, int y, int width, int height, uint8_t * data)
 {
 	int i, j, b;
 	int value;
@@ -371,13 +371,13 @@ void graphics_bitmap(struct graphics *g, int32_t x, int32_t y, int32_t width, in
 	}
 }
 
-void graphics_char(struct graphics *g, int32_t x, int32_t y, unsigned char c)
+void graphics_char(struct graphics *g, int x, int y, unsigned char c)
 {
 	uint32_t u = ((uint32_t) c) * FONT_WIDTH * FONT_HEIGHT / 8;
 	return graphics_bitmap(g, x, y, FONT_WIDTH, FONT_HEIGHT, &fontdata[u]);
 }
 
-void graphics_scrollup(struct graphics *g, int32_t x, int32_t y, int32_t w, int32_t h, int32_t dy)
+void graphics_scrollup(struct graphics *g, int x, int y, int w, int h, int dy)
 {
 	int j;
 

--- a/kernel/graphics.c
+++ b/kernel/graphics.c
@@ -21,7 +21,6 @@ struct graphics {
 	struct graphics_color fgcolor;
 	struct graphics_color bgcolor;
 	struct clip clip;
-	uint32_t count;
 	struct graphics *parent;
 	int refcount;
 };
@@ -37,7 +36,6 @@ struct graphics *graphics_create_root()
 	g->bitmap = bitmap_create_root();
 	g->fgcolor = color_white;
 	g->bgcolor = color_black;
-	g->count = 0;
 	g->clip.x = 0;
 	g->clip.y = 0;
 	g->clip.w = g->bitmap->width;
@@ -68,6 +66,11 @@ struct graphics *graphics_addref( struct graphics *g )
 
 void graphics_delete( struct graphics *g )
 {
+	if(!g) return;
+
+	/* Cannot delete the statically allocated root graphics */
+	if(g==&graphics_root) return;
+
 	g->refcount--;
 	if(g->refcount==0) {
 		graphics_delete(g->parent);

--- a/kernel/graphics.h
+++ b/kernel/graphics.h
@@ -25,17 +25,10 @@ struct clip {
 	uint32_t h;
 };
 
-struct graphics {
-	struct bitmap *bitmap;
-	struct graphics_color fgcolor;
-	struct graphics_color bgcolor;
-	struct clip clip;
-	uint32_t count;
-};
-
 struct graphics *graphics_create_root();
 
 struct graphics *graphics_create(struct graphics *parent );
+struct graphics *graphics_addref(struct graphics *g );
 void graphics_delete(struct graphics *g);
 
 int32_t graphics_width(struct graphics *g);

--- a/kernel/graphics.h
+++ b/kernel/graphics.h
@@ -18,15 +18,7 @@ struct graphics_color {
 	uint8_t a;
 };
 
-struct clip {
-	uint32_t x;
-	uint32_t y;
-	uint32_t w;
-	uint32_t h;
-};
-
 struct graphics *graphics_create_root();
-
 struct graphics *graphics_create(struct graphics *parent );
 struct graphics *graphics_addref(struct graphics *g );
 void graphics_delete(struct graphics *g);

--- a/kernel/graphics.h
+++ b/kernel/graphics.h
@@ -8,7 +8,6 @@ See the file LICENSE for details.
 #define GRAPHICS_H
 
 #include "kernel/types.h"
-#include "bitmap.h"
 #include "kernel/gfxstream.h"
 
 struct graphics_color {
@@ -18,24 +17,25 @@ struct graphics_color {
 	uint8_t a;
 };
 
+extern struct graphics graphics_root;
+
 struct graphics *graphics_create_root();
 struct graphics *graphics_create(struct graphics *parent );
 struct graphics *graphics_addref(struct graphics *g );
 void graphics_delete(struct graphics *g);
 
-int32_t graphics_width(struct graphics *g);
-int32_t graphics_height(struct graphics *g);
+uint32_t graphics_width(struct graphics *g);
+uint32_t graphics_height(struct graphics *g);
 void graphics_fgcolor(struct graphics *g, struct graphics_color c);
 void graphics_bgcolor(struct graphics *g, struct graphics_color c);
-int graphics_clip(struct graphics *g, int32_t x, int32_t y, int32_t w, int32_t h);
+int  graphics_clip(struct graphics *g, int x, int y, int w, int h);
 
-void graphics_scrollup(struct graphics *g, int32_t x, int32_t y, int32_t w, int32_t h, int32_t dy);
-void graphics_rect(struct graphics *g, int32_t x, int32_t y, int32_t w, int32_t h);
-void graphics_clear(struct graphics *g, int32_t x, int32_t y, int32_t w, int32_t h);
-void graphics_line(struct graphics *g, int32_t x, int32_t y, int32_t w, int32_t h);
-void graphics_char(struct graphics *g, int32_t x, int32_t y, unsigned char c);
+void graphics_scrollup(struct graphics *g, int x, int y, int w, int h, int dy);
+void graphics_rect(struct graphics *g, int x, int y, int w, int h);
+void graphics_clear(struct graphics *g, int x, int y, int w, int h);
+void graphics_line(struct graphics *g, int x, int y, int w, int h);
+void graphics_char(struct graphics *g, int x, int y, unsigned char c);
 
 int graphics_write(struct graphics *g, struct graphics_command *command);
 
-extern struct graphics graphics_root;
 #endif

--- a/kernel/kobject.c
+++ b/kernel/kobject.c
@@ -212,7 +212,7 @@ int kobject_close(struct kobject *kobject)
 			//device_close(kobject->data.device);
 			break;
 		case KOBJECT_PIPE:
-			pipe_close(kobject->data.pipe);
+			pipe_delete(kobject->data.pipe);
 			break;
 		default:
 			break;
@@ -284,7 +284,7 @@ int kobject_size(struct kobject *kobject, int *dims, int n)
 		}
 	case KOBJECT_PIPE:
 		if(n==1) {
-			dims[0] = PIPE_SIZE;
+			dims[0] = pipe_size(kobject->data.pipe);
 			return 0;
 		} else {
 			return KERROR_INVALID_REQUEST;

--- a/kernel/pipe.h
+++ b/kernel/pipe.h
@@ -8,26 +8,16 @@
 #define PIPE_H
 
 #include "kernel/types.h"
-#include "list.h"
 
-#define PIPE_SIZE (1024)
-
-struct pipe {
-	char *buffer;
-	int read_pos;
-	int write_pos;
-	int blocking;
-	int flushed;
-	struct list queue;
-};
-
-struct pipe *pipe_open();
-void pipe_close(struct pipe *p);
+struct pipe *pipe_create();
+struct pipe *pipe_addref( struct pipe *p );
+void pipe_delete(struct pipe *p);
 void pipe_flush(struct pipe *p);
 int pipe_set_blocking(struct pipe *p, int b);
 
 int pipe_write(struct pipe *p, char *buffer, int size);
 int pipe_read(struct pipe *p, char *buffer, int size);
 int pipe_read_nonblock(struct pipe *p, char *buffer, int size);
+int pipe_size( struct pipe *p);
 
 #endif

--- a/kernel/process.c
+++ b/kernel/process.c
@@ -39,7 +39,6 @@ void process_init()
 	current->ktable[1] = kobject_create_console(&console_root);
 	current->ktable[2] = kobject_addref(current->ktable[1]);
 	current->ktable[3] = kobject_create_graphics(&graphics_root);
-	graphics_root.count++;
 
 	current->state = PROCESS_STATE_READY;
 

--- a/kernel/syscall_handler.c
+++ b/kernel/syscall_handler.c
@@ -463,7 +463,7 @@ int sys_open_pipe()
 	if(fd < 0) {
 		return KERROR_NOT_FOUND;
 	}
-	struct pipe *p = pipe_open();
+	struct pipe *p = pipe_create();
 	if(!p) {
 		return KERROR_NOT_FOUND;
 	}


### PR DESCRIPTION
- Extended reference counting to pipes, graphics, and console.
- Made reference counting more consistent: only delete on count==0, consider <0 to be a no-op.
- kobject now deletes underlying objects consistently.
- pipe open/close -> create/delete

