### PR TITLE
Fix order of argv and argc

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -31,7 +31,7 @@ image: kernel/basekernel.img $(USER_PROGRAMS)
 	mkdir image image/boot image/bin image/data
 	cp kernel/basekernel.img image/boot
 	cp $(USER_PROGRAMS) image/bin
-	head -20001 /usr/share/dict/words > image/data/words
+	head -2000 /usr/share/dict/words > image/data/words
 
 basekernel.iso: image
 	${ISOGEN} -input-charset utf-8 -iso-level 2 -J -R -o $@ -b boot/basekernel.img image

--- a/Makefile
+++ b/Makefile
@@ -31,7 +31,7 @@ image: kernel/basekernel.img $(USER_PROGRAMS)
 	mkdir image image/boot image/bin image/data
 	cp kernel/basekernel.img image/boot
 	cp $(USER_PROGRAMS) image/bin
-	head -2000 /usr/share/dict/words > image/data/words
+	head -20001 /usr/share/dict/words > image/data/words
 
 basekernel.iso: image
 	${ISOGEN} -input-charset utf-8 -iso-level 2 -J -R -o $@ -b boot/basekernel.img image

--- a/Makefile
+++ b/Makefile
@@ -31,7 +31,7 @@ image: kernel/basekernel.img $(USER_PROGRAMS)
 	mkdir image image/boot image/bin image/data
 	cp kernel/basekernel.img image/boot
 	cp $(USER_PROGRAMS) image/bin
-	head -2000l /usr/share/dict/words > image/data/words
+	head -2000 /usr/share/dict/words > image/data/words
 
 basekernel.iso: image
 	${ISOGEN} -input-charset utf-8 -iso-level 2 -J -R -o $@ -b boot/basekernel.img image

--- a/include/library/syscalls.h
+++ b/include/library/syscalls.h
@@ -16,10 +16,10 @@ void syscall_debug(const char *str);
 
 void syscall_process_exit(int status);
 int syscall_process_yield();
-int syscall_process_run(const char *cmd, const char **argv, int argc);
-int syscall_process_wrun(const char *cmd, const char **argv, int argc, int * fds, int fd_len);
+int syscall_process_run(const char *cmd, int argc, const char **argv);
+int syscall_process_wrun(const char *cmd, int argc, const char **argv,  int * fds, int fd_len);
 int syscall_process_fork();
-int syscall_process_exec(const char *path, const char **argv, int argc);
+int syscall_process_exec(const char *path, int argc, const char **argv);
 int syscall_process_self();
 int syscall_process_parent();
 int syscall_process_kill(unsigned int pid);

--- a/kernel/kshell.c
+++ b/kernel/kshell.c
@@ -131,13 +131,13 @@ static int kshell_listdir(const char *path)
 	return 0;
 }
 
-static int kshell_execute(const char **argv, int argc)
+static int kshell_execute(int argc, const char **argv)
 {
 	const char *cmd = argv[0];
 
 	if(!strcmp(cmd, "start")) {
 		if(argc > 1) {
-			int pid = sys_process_run(argv[1], &argv[1], argc - 1);
+			int pid = sys_process_run(argv[1], argc - 1,  &argv[1]);
 			if(pid > 0) {
 				printf("started process %d\n", pid);
 				process_yield();
@@ -149,7 +149,7 @@ static int kshell_execute(const char **argv, int argc)
 		}
 	} else if(!strcmp(cmd, "exec")) {
 		if(argc > 1) {
-			sys_process_exec(argv[1], &argv[1], argc - 1);
+			sys_process_exec(argv[1], argc - 1, &argv[1]);
 			process_yield();
 			printf("couldn't exec %s\n", argv[1]);
 		} else {
@@ -157,7 +157,7 @@ static int kshell_execute(const char **argv, int argc)
 		}
 	} else if(!strcmp(cmd, "run")) {
 		if(argc > 1) {
-			int pid = sys_process_run(argv[1], &argv[1], argc - 1);
+			int pid = sys_process_run(argv[1], argc - 1, &argv[1]);
 			if(pid > 0) {
 				printf("started process %d\n", pid);
 				process_yield();
@@ -234,7 +234,7 @@ static int kshell_execute(const char **argv, int argc)
 	} else if(!strcmp(cmd, "stress")) {
 		while(1) {
 			const char *argv[] = { "test.exe", "arg1", "arg2", "arg3", "arg4", "arg5", 0 };
-			int pid = sys_process_run("/bin/test.exe", argv, 6);
+			int pid = sys_process_run("/bin/test.exe", 6, argv);
 			if(pid > 0) {
 				struct process_info info;
 				process_wait_child(pid, &info, -1);
@@ -378,7 +378,7 @@ int kshell_launch()
 		}
 
 		if(argc > 0) {
-			kshell_execute(argv, argc);
+			kshell_execute(argc, argv);
 		}
 	}
 

--- a/kernel/process.c
+++ b/kernel/process.c
@@ -142,7 +142,7 @@ void process_inherit(struct process *parent, struct process *child)
 			fds[i] = i;
 		} else {
 			fds[i] = -1;
-		}	
+		}
 	}
 	process_selective_inherit(parent, child, fds, PROCESS_MAX_OBJECTS);
 	kfree(fds);
@@ -548,8 +548,8 @@ void process_pass_arguments(struct process *p, int argc, char **argv)
 	const char *addr_of_addr_of_argv = esp;
 
 	/* Push the arguments to main */
-	PUSH_INTEGER(argc);
 	PUSH_INTEGER(addr_of_addr_of_argv);
+	PUSH_INTEGER(argc);
 
 	/* Final stack pointer should be below the last item. */
 	esp -= 4;

--- a/kernel/syscall_handler.c
+++ b/kernel/syscall_handler.c
@@ -33,7 +33,7 @@ syscall_handler() is responsible for decoding system calls
 as they arrive, converting raw integers into the appropriate
 types, depending on the system call number.  Then, each
 individual handler routine checks the validity of each
-argument (fd in range, valid path, etc) and invokes the 
+argument (fd in range, valid path, etc) and invokes the
 underlying system within the kernel.  Ideally, each of these
 handler functions should be short (only a few lines)
 and simply make use of functionality within other kernel modules.
@@ -98,7 +98,7 @@ way than fork/exec by creating the child without duplicating
 the memory state, then loading
 */
 
-int sys_process_run(const char *path, const char **argv, int argc)
+int sys_process_run(const char *path, int argc, const char **argv)
 {
 	if(!is_valid_path(path)) return KERROR_INVALID_PATH;
 
@@ -147,7 +147,7 @@ int sys_process_run(const char *path, const char **argv, int argc)
 }
 
 /* Function creates a child process with the standard window replaced by wd */
-int sys_process_wrun(const char *path, const char **argv, int argc, int *fds, int fd_len)
+int sys_process_wrun(const char *path, int argc, const char **argv, int *fds, int fd_len)
 {
 	if(!is_valid_path(path)) return KERROR_INVALID_PATH;
 
@@ -197,7 +197,7 @@ int sys_process_wrun(const char *path, const char **argv, int argc, int *fds, in
 	return p->pid;
 }
 
-int sys_process_exec(const char *path, const char **argv, int argc)
+int sys_process_exec(const char *path, int argc, const char **argv)
 {
 	if(!is_valid_path(path)) return KERROR_INVALID_PATH;
 
@@ -612,13 +612,13 @@ int32_t syscall_handler(syscall_t n, uint32_t a, uint32_t b, uint32_t c, uint32_
 	case SYSCALL_PROCESS_EXIT:
 		return sys_process_exit(a);
 	case SYSCALL_PROCESS_RUN:
-		return sys_process_run((const char *) a, (const char **) b, c);
+		return sys_process_run((const char *) a, b, (const char **)c);
 	case SYSCALL_PROCESS_WRUN:
-		return sys_process_wrun((const char *) a, (const char **) b, c, (int *) d, e);
+		return sys_process_wrun((const char *) a, b, (const char **) c, (int *) d, e);
 	case SYSCALL_PROCESS_FORK:
 		return sys_process_fork();
 	case SYSCALL_PROCESS_EXEC:
-		return sys_process_exec((const char *) a, (const char **) b, c);
+		return sys_process_exec((const char *) a, b, (const char **) c);
 	case SYSCALL_PROCESS_SELF:
 		return sys_process_self();
 	case SYSCALL_PROCESS_PARENT:

--- a/kernel/syscall_handler.h
+++ b/kernel/syscall_handler.h
@@ -3,8 +3,8 @@
 
 /* Only kernel/syscall.handlers invoked by other parts of kernel code should be declared here. */
 
-int sys_process_run(const char *path, const char **argv, int argc);
-int sys_process_exec(const char *path, const char **argv, int argc);
+int sys_process_run(const char *path, int argc, const char **argv);
+int sys_process_exec(const char *path, int argc, const char **argv);
 
 int sys_process_sleep(unsigned int ms);
 

--- a/library/syscalls.c
+++ b/library/syscalls.c
@@ -23,14 +23,14 @@ int syscall_process_yield()
 	return syscall(SYSCALL_PROCESS_YIELD, 0, 0, 0, 0, 0);
 }
 
-int syscall_process_run(const char *cmd, const char **argv, int argc)
+int syscall_process_run(const char *cmd, int argc, const char **argv)
 {
-	return syscall(SYSCALL_PROCESS_RUN, (uint32_t) cmd, (uint32_t) argv, argc, 0, 0);
+	return syscall(SYSCALL_PROCESS_RUN, (uint32_t) cmd, argc, (uint32_t) argv, 0, 0);
 }
 
-int syscall_process_wrun(const char *cmd, const char **argv, int argc, int * fds, int fd_len)
+int syscall_process_wrun(const char *cmd, int argc, const char **argv, int * fds, int fd_len)
 {
-	return syscall(SYSCALL_PROCESS_WRUN, (uint32_t) cmd, (uint32_t) argv, argc, (uint32_t) fds, fd_len);
+	return syscall(SYSCALL_PROCESS_WRUN, (uint32_t) cmd, argc, (uint32_t) argv, (uint32_t) fds, fd_len);
 }
 
 int syscall_process_fork()
@@ -38,9 +38,9 @@ int syscall_process_fork()
 	return syscall(SYSCALL_PROCESS_FORK, 0, 0, 0, 0, 0);
 }
 
-void syscall_process_exec(const char *path, const char **argv, int argc)
+void syscall_process_exec(const char *path, int argc, const char **argv)
 {
-	syscall(SYSCALL_PROCESS_EXEC, (uint32_t) path, (uint32_t) argv, (uint32_t) argc, 0, 0);
+	syscall(SYSCALL_PROCESS_EXEC, (uint32_t) path, argc, (uint32_t) argv, 0, 0);
 }
 
 int syscall_process_self()
@@ -207,5 +207,3 @@ int syscall_chdir(const char *path)
 {
 	return syscall(SYSCALL_CHDIR, (uint32_t) path, 0, 0, 0, 0);
 }
-
-

--- a/library/user-start.c
+++ b/library/user-start.c
@@ -15,9 +15,9 @@ must invoke the syscall_process_exit() system call to terminate the process.
 
 #include "library/syscalls.h"
 
-int main(const char *argv[], int argc);
+int main(int argc, const char *argv[]);
 
-void _start(const char **argv, int argc)
+void _start(int argc, const char **argv)
 {
-	syscall_process_exit(main(argv, argc));
+	syscall_process_exit(main(argc, argv));
 }

--- a/user/ball.c
+++ b/user/ball.c
@@ -17,8 +17,10 @@ typedef unsigned int uint32_t;
 uint32_t randint(uint32_t min, uint32_t max);
 void move(int *x, int *d, int min, int max);
 
-int main(const char *argv[], int argc)
+int main(int argc, char *argv[])
 {
+	printf("%s\n", argv[0]);
+	return 0;
 	int r = 255;
 	int g = 0;
 	int b = 0;

--- a/user/ball.c
+++ b/user/ball.c
@@ -19,8 +19,6 @@ void move(int *x, int *d, int min, int max);
 
 int main(int argc, char *argv[])
 {
-	printf("%s\n", argv[0]);
-	return 0;
 	int r = 255;
 	int g = 0;
 	int b = 0;

--- a/user/clock.c
+++ b/user/clock.c
@@ -10,7 +10,7 @@ See the file LICENSE for details.
 #include "library/user-io.h"
 #include "kernel/types.h"
 
-/* 
+/*
 	Display time in a window
 */
 
@@ -18,7 +18,7 @@ See the file LICENSE for details.
 void draw_border(int x, int y, int w, int h, int thickness, int r, int g, int b);
 void draw_clock(uint32_t hour, uint32_t minute, int timezone, int military, int x, int y, int padding, int r, int g, int b);
 
-int main(const char ** argv, int argc) 
+int main(int argc, char *argv[])
 {
 	/* Configure clock params */
 	int military = 0;
@@ -59,7 +59,7 @@ int main(const char ** argv, int argc)
 	return 0;
 }
 
-void draw_border(int x, int y, int w, int h, int thickness, int r, int g, int b) 
+void draw_border(int x, int y, int w, int h, int thickness, int r, int g, int b)
 {
 	draw_color(r, b, g);
 	draw_rect(x, y, w, thickness);
@@ -77,12 +77,12 @@ void draw_clock(uint32_t hour, uint32_t minute, int timezone, int military, int 
 
 	/* Configure time */
 	int tz_hour = (int)hour - timezone;
-	if (tz_hour < 0) 
+	if (tz_hour < 0)
 	{
 		tz_hour += 24;
 	}
 
-	if (military == 0 && tz_hour > 12) 
+	if (military == 0 && tz_hour > 12)
 	{
 		tz_hour -= 12;
 	}
@@ -91,13 +91,13 @@ void draw_clock(uint32_t hour, uint32_t minute, int timezone, int military, int 
 	uint_to_string(minute, m_str);
 
 	/* Format time string */
-	if (strlen(h_str) == 1) 
+	if (strlen(h_str) == 1)
 	{
 		strcat(time, " ");
 	}
 	strcat(time, (const char *) h_str);
 	strcat(time, ":");
-	if (strlen(m_str) == 1) 
+	if (strlen(m_str) == 1)
 	{
 		strcat(time, "0");
 	}

--- a/user/copy.c
+++ b/user/copy.c
@@ -10,8 +10,10 @@ See the file LICENSE for details.
 #include "library/string.h"
 #include "library/errno.h"
 
-int main(int argc, char const *argv[])
+int main(int argc, char *argv[])
 {
+	printf("%s\n", argv[0]);
+	return 0;
 	if(argc!=3) {
 		printf("%s: <sourcepath> <destpath>\n");
 		return 1;

--- a/user/copy.c
+++ b/user/copy.c
@@ -12,8 +12,6 @@ See the file LICENSE for details.
 
 int main(int argc, char *argv[])
 {
-	printf("%s\n", argv[0]);
-	return 0;
 	if(argc!=3) {
 		printf("%s: <sourcepath> <destpath>\n");
 		return 1;

--- a/user/exectest.c
+++ b/user/exectest.c
@@ -8,7 +8,7 @@ int main(int argc, char *argv[])
 	if (pid == 0) {
 		printf("hello world, I am the child %d.\n", syscall_process_self());
 		const char *args[] = { "snake.exe" };
-		syscall_process_exec("snake.exe", args, 1);
+		syscall_process_exec("snake.exe", 1, args);
 	} else {
 		printf("hello world, I am the parent %d.\n", syscall_process_self());
 		struct process_info info;

--- a/user/exectest.c
+++ b/user/exectest.c
@@ -1,7 +1,7 @@
 #include "library/syscalls.h"
 #include "library/string.h"
 
-int main()
+int main(int argc, char *argv[])
 {
 	int pid = syscall_process_fork();
 

--- a/user/filedescribetest.c
+++ b/user/filedescribetest.c
@@ -6,7 +6,7 @@
 
 #define INTENT_BUFFER_SIZE 256
 
-int main(const char **argv, int argc)
+int main(int argc, char *argv[])
 {
 	char *intent_value = "A simple intent string";
 

--- a/user/forktest.c
+++ b/user/forktest.c
@@ -1,7 +1,7 @@
 #include "library/syscalls.h"
 #include "library/string.h"
 
-int main(const char *argv[], int argc)
+int main(int argc, char *argv[])
 {
 	printf("hello world, I am %d.\n", syscall_process_self());
 	int x = syscall_process_fork();

--- a/user/long.c
+++ b/user/long.c
@@ -73,7 +73,7 @@ char *shakespeare[] = {
 	"Ordenance are shot off.",
 };
 
-int main(const char *argv[], int argc)
+int main(int argc, char *argv[])
 {
 	int i;
 	for(i = 0; i < sizeof(shakespeare) / sizeof(char *); i++) {

--- a/user/manager.c
+++ b/user/manager.c
@@ -9,7 +9,7 @@ See the file LICENSE for details.
 #include "library/string.h"
 #include "library/user-io.h"
 
-/* 
+/*
 	Have a list of programs and windows that we want to run in certain sized windows
 	and place them across the screen
 */
@@ -30,7 +30,8 @@ void mergeSort(program * programs, int l, int r);
 void merge(program * arr, int l, int m, int r);
 
 
-int main(const char ** argv, int argc) {
+int main(int argc, char *argv[])
+{
 	/* Eventually, programs wont be hardcoded */
 	const char *args1[] = { "/bin/snake.exe" };
 	const char *args2[] = { "/bin/clock.exe", "08:40" };
@@ -137,7 +138,7 @@ int main(const char ** argv, int argc) {
 			draw_border(placement[p_act][0] - 2*padding, placement[p_act][1] - 2*padding, programs[p_act].w + 4*padding, programs[p_act].h + 4*padding, padding, 255, 255, 255);
 			draw_flush();
 			p_act = (p_act + 1) % num_programs;
-			
+
 			/* Draw green window around active process and start it */
 			draw_window(KNO_STDWIN);
 			draw_border(placement[p_act][0] - 2*padding, placement[p_act][1] - 2*padding, programs[p_act].w + 4*padding, programs[p_act].h + 4*padding, padding, 0, 0, 255);

--- a/user/manager.c
+++ b/user/manager.c
@@ -110,7 +110,7 @@ int main(int argc, char *argv[])
 		fds[p_i][2] = fds[p_i][1];
 
 		// Take in an array of FD's
-		pids[p_i] = syscall_process_wrun(programs[p_i].exec, programs[p_i].args, programs[p_i].argc, fds[p_i], 4);
+		pids[p_i] = syscall_process_wrun(programs[p_i].exec, programs[p_i].argc, programs[p_i].args, fds[p_i], 4);
 		draw_window(KNO_STDWIN);
 		draw_border(placement[p_i][0] - 2*padding, placement[p_i][1] - 2*padding, programs[p_i].w + 4*padding, programs[p_i].h + 4*padding, padding, 255, 255, 255);
 		draw_flush();

--- a/user/mandelbrot.c
+++ b/user/mandelbrot.c
@@ -25,7 +25,7 @@ typedef struct Complex {
 int in_set(Complex c);
 void plot_point(int iter_val, int j, int k);
 
-int main(const char ** argv, int argc)
+int main(int argc, char *argv[])
 {
 	/* Set up params */
 	int dim = 400;

--- a/user/open.c
+++ b/user/open.c
@@ -8,7 +8,7 @@ See the file LICENSE for details.
 #include "library/string.h"
 #include "library/user-io.h"
 
-int main(const char *argv[], int argc)
+int main(int argc, char *argv[])
 {
 	syscall_chdir("/");
 	printf("got root\n");

--- a/user/pipetest.c
+++ b/user/pipetest.c
@@ -2,7 +2,7 @@
 #include "library/user-io.h"
 #include "library/string.h"
 
-int main(const char *argv[], int argc)
+int main(int argc, char *argv[])
 {
 	printf("%d: Running pipe test!\n", syscall_process_self());
 	int w = syscall_open_pipe();

--- a/user/printer.c
+++ b/user/printer.c
@@ -15,7 +15,7 @@ A fun graphics demo that features a line segment bouncing around the screen.
 #define WIDTH    (200)
 #define HEIGHT   (200)
 
-int main(const char *argv[], int argc)
+int main(int argc, char *argv[])
 {
 	draw_window(KNO_STDWIN);
 	draw_color(0, 0, 255);

--- a/user/procstat.c
+++ b/user/procstat.c
@@ -9,7 +9,8 @@ See the file LICENSE for details.
 #include "kernel/stats.h"
 #include "library/string.h"
 
-int main(int argc, char const *argv[]) {
+int main(int argc, char *argv[])
+{
 	if (argc <= 1) {
 		printf("No program to run\n");
 		return 1;

--- a/user/procstat.c
+++ b/user/procstat.c
@@ -9,7 +9,7 @@ See the file LICENSE for details.
 #include "kernel/stats.h"
 #include "library/string.h"
 
-int main(int argc, char *argv[])
+int main(int argc, const char *argv[])
 {
 	if (argc <= 1) {
 		printf("No program to run\n");
@@ -19,7 +19,7 @@ int main(int argc, char *argv[])
 	syscall_system_time(&startTime);
 	int pid = syscall_process_fork();
 	if (pid == 0) { // child
-		syscall_process_exec(argv[1], &argv[1], argc-1);
+		syscall_process_exec(argv[1], argc-1, &argv[1]);
 		printf("exec failed\n");
 		return 1;
 	} else if (pid < 0) {

--- a/user/saver.c
+++ b/user/saver.c
@@ -17,7 +17,7 @@ typedef unsigned int uint32_t;
 uint32_t randint(uint32_t min, uint32_t max);
 void move(int *x, int *d, int min, int max);
 
-int main(const char *argv[], int argc)
+int main(int argc, char *argv[])
 {
 	int r = 255;
 	int g = 0;

--- a/user/shell.c
+++ b/user/shell.c
@@ -36,7 +36,7 @@ int do_command(char *line)
 			if(pid != 0) {
 				printf("started process %d\n", pid);
 			} else {
-				syscall_process_exec(pch, argv, 2);
+				syscall_process_exec(pch, 2, argv);
 			}
 		} else
 			printf("start: missing argument\n");
@@ -50,7 +50,7 @@ int do_command(char *line)
 			while((next = strtok(0, " "))) {
 				argv[i++] = next;
 			}
-			int pid = syscall_process_run(argv[0], &argv[0], i);
+			int pid = syscall_process_run(argv[0], i,  &argv[0]);
 			if(pid > 0) {
 				printf("started process %d\n", pid);
 				syscall_process_yield();

--- a/user/shell.c
+++ b/user/shell.c
@@ -120,7 +120,7 @@ int do_command(char *line)
 	return 0;
 }
 
-int main(char **argv, int argc)
+int main(int argc, char *argv[])
 {
 	printf("User shell ready:\n");
 	char line[1024];

--- a/user/snake.c
+++ b/user/snake.c
@@ -35,7 +35,7 @@ void update_snake(struct coords *snake_coords, uint16_t x_next, uint16_t y_next,
 void update_board(struct coords *snake_coords, uint8_t * board, uint16_t x_steps, uint16_t y_steps);
 
 /* Main Execution */
-int main(const char *argv[], int argc)
+int main(int argc, char *argv[])
 {
 	uint16_t WIDTH = 200;
 	uint16_t HEIGHT = 200;

--- a/user/sysstat.c
+++ b/user/sysstat.c
@@ -7,7 +7,8 @@ See the file LICENSE for details.
 #include "library/syscalls.h"
 #include "library/string.h"
 
-int main(int argc, char const *argv[]) {
+int main(int argc, char *argv[])
+{
 	struct system_stats s = {0};
 	if (syscall_system_stats(&s)) {
 		return 1;

--- a/user/test.c
+++ b/user/test.c
@@ -8,7 +8,7 @@ See the file LICENSE for details.
 #include "library/string.h"
 #include "library/malloc.h"
 
-int main(const char *argv[], int argc)
+int main(int argc, char *argv[])
 {
 	printf("hello world, I am %d, and I have %d arguments!\n", syscall_process_self(), argc);
 

--- a/user/write.c
+++ b/user/write.c
@@ -12,7 +12,7 @@ A trivial user level program to try out basic system calls.
 #include "library/string.h"
 #include "library/user-io.h"
 
-int main(const char *argv[], int argc)
+int main(int argc, char *argv[])
 {
 	uint32_t j = 0;
 	syscall_chdir("/");

--- a/user/writebig.c
+++ b/user/writebig.c
@@ -12,7 +12,7 @@ A trivial user level program to try out basic system calls.
 #include "library/string.h"
 #include "library/user-io.h"
 
-int main(int argc, const char *argv[])
+int main(int argc, char *argv[])
 {
 	syscall_chdir("/");
 	printf("got root\n");


### PR DESCRIPTION
In response to #233 , I fixed the order of argv and argc in all programs that use them.

The Unix convention is to have argc before argv. However, we have been doing argv before argc.

So, throughout all of the user programs, I switched the order to be argc, argv for their main functions. I also changed the system calls to follow that convention as well. I also changed library/user-start.c

In the kernel, I adjusted systemcall_handler accordingly, and changed process_pass_arguments to push argc after it pushes argv.

I tested it by running user/test.exe with different numbers of arguments.