### PR TITLE
Dup args

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -31,7 +31,7 @@ image: kernel/basekernel.img $(USER_PROGRAMS)
 	mkdir image image/boot image/bin image/data
 	cp kernel/basekernel.img image/boot
 	cp $(USER_PROGRAMS) image/bin
-	head -20001 /usr/share/dict/words > image/data/words
+	head -2000 /usr/share/dict/words > image/data/words
 
 basekernel.iso: image
 	${ISOGEN} -input-charset utf-8 -iso-level 2 -J -R -o $@ -b boot/basekernel.img image

--- a/Makefile
+++ b/Makefile
@@ -31,7 +31,7 @@ image: kernel/basekernel.img $(USER_PROGRAMS)
 	mkdir image image/boot image/bin image/data
 	cp kernel/basekernel.img image/boot
 	cp $(USER_PROGRAMS) image/bin
-	head -2000 /usr/share/dict/words > image/data/words
+	head -20001 /usr/share/dict/words > image/data/words
 
 basekernel.iso: image
 	${ISOGEN} -input-charset utf-8 -iso-level 2 -J -R -o $@ -b boot/basekernel.img image

--- a/Makefile
+++ b/Makefile
@@ -31,7 +31,7 @@ image: kernel/basekernel.img $(USER_PROGRAMS)
 	mkdir image image/boot image/bin image/data
 	cp kernel/basekernel.img image/boot
 	cp $(USER_PROGRAMS) image/bin
-	head -2000l /usr/share/dict/words > image/data/words
+	head -2000 /usr/share/dict/words > image/data/words
 
 basekernel.iso: image
 	${ISOGEN} -input-charset utf-8 -iso-level 2 -J -R -o $@ -b boot/basekernel.img image

--- a/kernel/syscall_handler.c
+++ b/kernel/syscall_handler.c
@@ -33,7 +33,7 @@ syscall_handler() is responsible for decoding system calls
 as they arrive, converting raw integers into the appropriate
 types, depending on the system call number.  Then, each
 individual handler routine checks the validity of each
-argument (fd in range, valid path, etc) and invokes the 
+argument (fd in range, valid path, etc) and invokes the
 underlying system within the kernel.  Ideally, each of these
 handler functions should be short (only a few lines)
 and simply make use of functionality within other kernel modules.
@@ -431,25 +431,22 @@ int sys_object_type(int fd)
 	return fd_type;
 }
 
-// XXX the direction of dup here is backwards from the typical unix,
-// which dups the second argument into the first.
-
 int sys_object_dup(int fd1, int fd2)
 {
-	if(!is_valid_object(fd1)) return KERROR_INVALID_OBJECT;
-	if(fd2>PROCESS_MAX_OBJECTS) return KERROR_INVALID_OBJECT;
+	if(!is_valid_object(fd2)) return KERROR_INVALID_OBJECT;
+	if(fd1>PROCESS_MAX_OBJECTS) return KERROR_INVALID_OBJECT;
 
-	if(fd2 < 0) {
-		fd2 = process_available_fd(current);
-		if(!fd2) {
+	if(fd1 < 0) {
+		fd1 = process_available_fd(current);
+		if(!fd1) {
 			return KERROR_NOT_FOUND;
 		}
 	}
-	if(current->ktable[fd2]) {
-		kobject_close(current->ktable[fd2]);
+	if(current->ktable[fd1]) {
+		kobject_close(current->ktable[fd1]);
 	}
-	current->ktable[fd2] = kobject_addref(current->ktable[fd1]);
-	return fd2;
+	current->ktable[fd1] = kobject_addref(current->ktable[fd2]);
+	return fd1;
 }
 
 int sys_object_read(int fd, void *data, int length)

--- a/user/pipetest.c
+++ b/user/pipetest.c
@@ -10,7 +10,7 @@ int main(const char *argv[], int argc)
 	int x = syscall_process_fork();
 	if(x) {
 		printf("%d: Writing...\n", syscall_process_self());
-		syscall_object_dup(w, KNO_STDOUT);
+		syscall_object_dup(KNO_STDOUT, w);
 		printf("Testing!\n");
 		syscall_process_sleep(1000);
 	} else {

--- a/user/printer.c
+++ b/user/printer.c
@@ -27,7 +27,7 @@ int main(const char *argv[], int argc)
 		printf("Console open failed!\n");
 		return 2;
 	}
-	syscall_object_dup(cd, KNO_STDOUT);
+	syscall_object_dup(KNO_STDOUT, cd);
 
 	printf("hello world!\n");
 


### PR DESCRIPTION
Addresses #243 . Changed the order of arguments in the system call sys_object_dup to match the Unix standard. Now, the second argument dups into the first.

Only 2 user programs used this system call: pipetest and printer.