### PR TITLE
Fix multiply defined boottime.

### DIFF
--- a/kernel/rtc.c
+++ b/kernel/rtc.c
@@ -76,6 +76,8 @@ Recommended reading: page 11-15 of the RTC data sheet
 
 #define LEAP_YEAR(Y) ( (Y>0) && !(Y%4) && ( (Y%100) || !(Y%400) ) )
 
+uint32_t boottime;
+
 static const uint8_t monthDays[] = { 31, 28, 31, 30, 31, 30, 31, 31, 30, 31, 30, 31 };
 
 static uint8_t rtc_bcd_to_binary(uint8_t bcd)

--- a/kernel/rtc.h
+++ b/kernel/rtc.h
@@ -9,7 +9,7 @@ See the file LICENSE for details.
 
 #include "kernel/types.h"
 
-uint32_t boottime;
+extern uint32_t boottime;
 
 void rtc_init();
 void rtc_read(struct rtc_time *t);


### PR DESCRIPTION
Made boottime extern in rtc.h, and defined it in rtc.c.  This fixes a linker error