### PR TITLE
Fix serial_read function to actually return the character

### DIFF
--- a/kernel/serial.c
+++ b/kernel/serial.c
@@ -99,8 +99,7 @@ char serial_read(uint8_t port_no)
 		return -1;
 
 	while(serial_received(serial_ports[port_no]) == 0);
-	inb(serial_ports[port_no]);
-	return 0;
+	return inb(serial_ports[port_no]);
 }
 
 int serial_write(uint8_t port_no, char a)


### PR DESCRIPTION
Currently `serial_read` calls `inb` but doesn't return the character. This commit fixes that.

Sorry if I should create an issue instead, but I don't see any way for user programs to access the serial. Is there something I have missed ? (If it doesn't exist, its fine, I can hack on it)