### PR TITLE
Fix kernel/clock.c to configure PIT properly

### DIFF
--- a/kernel/clock.c
+++ b/kernel/clock.c
@@ -9,13 +9,14 @@ See the file LICENSE for details.
 #include "ioports.h"
 #include "process.h"
 
-#define CLICKS_PER_SECOND 10
+// Minimum PIT frequency is 18.2Hz.
+#define CLICKS_PER_SECOND 20
 
 #define TIMER0		0x40
 #define TIMER_MODE	0x43
 #define SQUARE_WAVE     0x36
 #define TIMER_FREQ	1193182
-#define TIMER_COUNT	(((unsigned)TIMER_FREQ)/CLICKS_PER_SECOND/2)
+#define TIMER_COUNT	(((unsigned)TIMER_FREQ)/CLICKS_PER_SECOND)
 
 static uint32_t clicks = 0;
 static uint32_t seconds = 0;


### PR DESCRIPTION
Fixed a bug where the clock ticked twice as fast. This commit bumps the frequency (CLICKS_PER_SECOND) to 20, and sets the PIT counter to the correct value.

Closes #288 