### PR TITLE
elf: Load all sections.

### DIFF
--- a/kernel/elf.c
+++ b/kernel/elf.c
@@ -104,8 +104,10 @@ static int elf_ensure_address_space( struct process *p, uint32_t addr )
 	if(limit > p->vm_data_size) {
 		return process_data_size_set(p,limit);
 	} else {
-		return 1;
+		return 0;
 	}
+
+	/* Return zero on success. */
 }
  
 int elf_load(struct process *p, struct fs_dirent *d, addr_t * entry)
@@ -146,12 +148,12 @@ int elf_load(struct process *p, struct fs_dirent *d, addr_t * entry)
 		if(section.type == ELF_SECTION_TYPE_BSS) {
 			/* For BSS, just clear that address space to zero. */
 			actual = elf_ensure_address_space(p,section.address+section.size);
-			if(!actual) goto nomem;
+			if(actual!=0) goto nomem;
 			memset((void *) section.address, section.size, 0);
 		} else if(section.type == ELF_SECTION_TYPE_PROGRAM && section.address!=0) {
 			/* For other loadable section types (usually data), load from file. */
 			actual = elf_ensure_address_space(p,section.address+section.size);
-			if(!actual) goto nomem;
+			if(actual!=0) goto nomem;
 			actual = fs_dirent_read(d,(char*)section.address,section.size,section.offset);
 			if(actual != section.size) goto mustdie;
 		} else {

--- a/kernel/kshell.c
+++ b/kernel/kshell.c
@@ -387,6 +387,8 @@ int kshell_launch()
 	const char *argv[100];
 	int argc;
 
+	kshell_mount("atapi",2,"cdromfs");
+	
 	while(1) {
 		printf("kshell> ");
 		kshell_readline(line, sizeof(line));

--- a/kernel/main.c
+++ b/kernel/main.c
@@ -39,7 +39,7 @@ int kernel_main()
 	struct console *console = console_create_root();
 	console_addref(console);
 
-	printf("video: %d x %d\n", video_xres, video_yres, video_xbytes);
+	printf("video: %d x %d (addr %x)\n", video_xres, video_yres, video_buffer);
 	printf("kernel: %d bytes\n", kernel_size);
 
 	page_init();
@@ -60,6 +60,7 @@ int kernel_main()
 	current->ktable[KNO_STDWIN]  = kobject_create_window(&window_root);
 	current->ktable[KNO_STDDIR]  = 0; // No current dir until something is mounted.
 
+	
 	printf("\n");
 	kshell_launch();
 

--- a/kernel/page.c
+++ b/kernel/page.c
@@ -82,6 +82,7 @@ void *page_alloc(bool zeroit)
 					if(zeroit)
 						memset(pageaddr, 0, PAGE_SIZE);
 					pages_free--;
+					printf("page: alloc %d\n",pages_free);
 					return pageaddr;
 				}
 			}
@@ -102,4 +103,5 @@ void page_free(void *pageaddr)
 	uint32_t cellmask = (1 << celloffset);
 	freemap[cellnumber] |= cellmask;
 	pages_free++;
+	printf("page: free %d\n",pages_free);
 }

--- a/kernel/pipe.c
+++ b/kernel/pipe.c
@@ -24,7 +24,13 @@ struct pipe {
 struct pipe *pipe_create()
 {
 	struct pipe *p = kmalloc(sizeof(*p));
+	if(!p) return 0;
+	
 	p->buffer = page_alloc(1);
+	if(!p->buffer) {
+		kfree(p);
+		return 0;
+	}
 	p->read_pos = 0;
 	p->write_pos = 0;
 	p->flushed = 0;


### PR DESCRIPTION
By mistake, `elf` was not loading all data sections of programs.  This would show up in errors related to initialization of global structures. 
