### PR TITLE
Clean up Cross-Compile and Instructions

### DIFF
--- a/Makefile.config
+++ b/Makefile.config
@@ -1,24 +1,39 @@
+# By default, attempt to compile using the host compiler toolchain.
+# If you have built the cross-compiler, then set this to true instead.
+CROSS_COMPILE=true
+
+# This roundabout method finds the directory containing this Makefile.config.
+THISFILE_PATH := $(abspath $(lastword $(MAKEFILE_LIST)))
+THISFILE_DIR := $(dir $(THISFILE_PATH))
+
+ifeq ($(CROSS_COMPILE),true)
+    # Select the cross-compilation tools.
+    CROSS := $(THISFILE_DIR)/cross
+    CC=$(CROSS)/bin/i686-elf-gcc
+    LD=$(CROSS)/bin/i686-elf-ld
+    KERNEL_LD=$(CROSS)/bin/i686-elf-ld
+    AR=$(CROSS)/bin/i686-elf-ar
+    OBJCOPY=$(CROSS)/bin/i686-elf-objcopy
+else
+    # Select the host tools instead.
+    CC=gcc -m32
+    LD=ld
+    KERNEL_LD=ld -melf_i386
+    AR=ar
+    OBJCOPY=objcopy
+endif
+
+# Compiler and linker settings for the kernel proper:
 KERNEL_CCFLAGS=-Wall -c -ffreestanding -fno-pie -g -std=gnu99
+KERNEL_LDFLAGS=
 
-# These settings select the native compiler,
-# which is likely to work on native linux-x86.
-#
-CC=gcc -m32
-LD=ld
-KERNEL_LD=ld -melf_i386
-AR=ar
-OBJCOPY=objcopy
+# Compiler and linker settings for the library and user code:
+USER_CCFLAGS=-Wall -c -ffreestanding -fno-pie -g -std=gnu99
+USER_LDFLAGS=-z max-page-size=4096 -T basekernel.user.ldscript
+
+# Linux machines typically install genisoimage for cdrom imaging.
 ISOGEN=genisoimage
-
-# If you are compiling from another platform,
-# then use the script build-cross-compiler.sh
-# add cross/bin to your path, and uncomment these lines:
-#CC=i686-elf-gcc
-#LD=i686-elf-ld
-#KERNEL_LD=i686-elf-ld
-#AR=i686-elf-ar
-#OBJCOPY=i686-elf-objcopy
-
 # If building on OSX, then install mkisofs via ports or brew
 # and uncomment this:
 #ISOGEN=mkisofs
+

--- a/Makefile.config
+++ b/Makefile.config
@@ -1,6 +1,6 @@
 # By default, attempt to compile using the host compiler toolchain.
 # If you have built the cross-compiler, then set this to true instead.
-CROSS_COMPILE=true
+CROSS_COMPILE=false
 
 # This roundabout method finds the directory containing this Makefile.config.
 THISFILE_PATH := $(abspath $(lastword $(MAKEFILE_LIST)))

--- a/README.md
+++ b/README.md
@@ -25,7 +25,8 @@ To learn more, see the [Basekernel Wiki](https://github.com/dthain/basekernel/wi
 ## Quick Start Instructions
 
 If you are building on a Linux-X86 machine
-and have the QEMU virtual machine installed:
+and have the QEMU virtual machine installed,
+then it could be as easy as this to build and run:
 
 ```
 git clone https://github.com/dthain/basekernel
@@ -34,7 +35,7 @@ make
 qemu-system-i386 -cdrom basekernel.iso
 ```
 
-And you should see something like this:
+You should see something like this:
 
 <img src=screenshot.png align=center>
 
@@ -68,11 +69,19 @@ run /bin/manager.exe
 Press TAB to change the focus between windows,
 and you can interact with each process in turn.
 
-## Cross-Compiling Instructions
+## Not So Quick Start Instructions
 
-If you are building on any other type of machine,
-you will probably need to build a cross-compiler
-using `build-cross-compiler.sh` and then edit
-`Makefile.config` to use the cross compiler binaries,
-then execute `make` to create `basekernel.iso`
+If you are building on any other type of machine (not Linux or not-X86)
+then you will need to build a cross-compiler toolchain first:
 
+1 - Run `./build-cross-compiler.sh` which will download and build the necessary compiler, linker,
+debugger, etc to create and run 32-bit X86 code.  **Be patient: this could take an hour or longer to complete.**
+
+2 - Double-check that the cross-compiler was built correctly:
+```
+i686-elf-gcc --version
+```
+
+3 - Modify `Makefile.config` and set `CROSS_COMPILE=true`
+
+4 - Build with `make` and then proceed as normal.

--- a/library/Makefile
+++ b/library/Makefile
@@ -5,7 +5,7 @@ LIBRARY_OBJECTS=errno.o syscall.o syscalls.o string.o stdio.o stdlib.o malloc.o 
 all: user-start.o baselib.a
 
 %.o: %.c
-	${CC} ${KERNEL_CCFLAGS} -I ../include $< -o $@
+	${CC} ${USER_CCFLAGS} -I ../include $< -o $@
 
 baselib.a: ${LIBRARY_OBJECTS}
 	${AR} rv $@ ${LIBRARY_OBJECTS}

--- a/user/Makefile
+++ b/user/Makefile
@@ -6,10 +6,10 @@ USER_PROGRAMS=ball.exe clock.exe copy.exe livestat.exe manager.exe fractal.exe p
 all: $(USER_PROGRAMS)
 
 %.o: %.c
-	${CC} ${KERNEL_CCFLAGS} -I ../include $< -o $@
+	${CC} ${USER_CCFLAGS} -I ../include $< -o $@
 
 %.exe: %.o ../library/user-start.o ../library/baselib.a
-	${LD} -z max-page-size=4096 -T basekernel.user.ldscript $< ../library/baselib.a -o $@ -Map $@.map
+	${LD} ${USER_LDFLAGS} $< ../library/baselib.a -o $@
 
 clean:
 	rm -rf *.exe *.o


### PR DESCRIPTION
- Update makefiles to simplify selection of cross-compile.
- Separate USER and KERNEL LDFLAGS and CCFLAGS.
- Update cross-compilation instructions accordingly.